### PR TITLE
[ FE ] feat/#8 Annotation 컴포넌트 코드 이동 및 리팩토링

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "next": "15.2.2",
     "openseadragon": "^5.0.1",
     "react": "^19.0.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.4"

--- a/frontend/src/app/main/projects/annotation/[id]/layout.tsx
+++ b/frontend/src/app/main/projects/annotation/[id]/layout.tsx
@@ -1,0 +1,16 @@
+import AnnotationHeader from '@/components/annotation/annotation-header';
+
+export default function AnnotationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-screen w-full flex-col gap-20 overflow-hidden overscroll-none">
+      <div className="sticky top-0 z-10">
+        <AnnotationHeader />
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/main/projects/annotation/[id]/page.tsx
+++ b/frontend/src/app/main/projects/annotation/[id]/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
+import { dummyProjects } from '@/data/dummy';
+import { Project } from '@/types/project-schema';
+
+// 프로젝트에 modelType을 추가한 타입 (필요한 경우 확장)
+type ProjectWithModel = Project & {
+  modelType?: string;
+};
+
+const OSDViewer = dynamic(
+  () => import('@/components/annotation/annotation-viewer'),
+  {
+    ssr: false,
+  },
+) as unknown as React.FC<{ annotations: any[]; modelType: string }>;
+
+export default function Annotation({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const [resolvedParams, setResolvedParams] = useState<{ id: string } | null>(
+    null,
+  );
+  const [project, setProject] = useState<ProjectWithModel | null>(null);
+
+  // URL 파라미터의 id와 일치하는 프로젝트를 dummyProjects 배열에서 찾고, modelType을 추가합니다.
+  useEffect(() => {
+    params.then((p) => {
+      setResolvedParams(p);
+      const found = dummyProjects.find((proj) => proj.id === Number(p.id));
+      if (found) {
+        const extendedProject: ProjectWithModel = {
+          ...found,
+          modelType: 'MULTI', // 필요에 따라 다른 값으로 설정 가능
+        };
+        setProject(extendedProject);
+      } else {
+        console.error('해당 id의 데이터가 없습니다.');
+      }
+    });
+  }, [params]);
+
+  useEffect(() => {
+    console.log('Resolved Params:', resolvedParams);
+  }, [resolvedParams]);
+
+  return (
+    <div>
+      <div>
+        {/* OSDViewer에 어노테이션 데이터 대신 빈 배열과 modelType 전달 */}
+        <OSDViewer annotations={[]} modelType={project?.modelType || 'MULTI'} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/main/projects/page.tsx
+++ b/frontend/src/app/main/projects/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { dummyProjects } from '@/data/dummy';
+import { Project } from '@/types/project-schema';
+
+export default function ProjectsPage() {
+  const router = useRouter();
+
+  return (
+    <div>
+      Projects
+      {dummyProjects.map((project: Project) => (
+        <Button
+          key={project.id}
+          onClick={() => router.push(`/main/projects/annotation/${project.id}`)}
+        >
+          {project.title} 열기
+        </Button>
+      ))}
+      <Button>새로운 프로젝트 생성</Button>
+    </div>
+  );
+}

--- a/frontend/src/components/annotation/annotation-header.tsx
+++ b/frontend/src/components/annotation/annotation-header.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter, useParams } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { dummyProjects } from '@/data/dummy';
+
+export default function AnnotationHeader() {
+  const router = useRouter();
+  const { id } = useParams(); // 현재 프로젝트 ID 가져오기
+
+  if (!id) return null; // ID가 없으면 렌더링하지 않음
+
+  // dummyProjects 배열에서 현재 id와 일치하는 프로젝트 찾기
+  const project = dummyProjects.find((proj) => proj.id === Number(id));
+
+  return (
+    <div className="bg-primary fixed right-0 top-0 w-full border-b border-white p-4 text-white">
+      <div className="flex flex-row items-center gap-4">
+        <button onClick={() => router.push('/main/projects')}>
+          <ArrowLeft className="text-white" />
+        </button>
+        <h3 className="text-lg font-semibold">
+          {project ? project.title : 'Project Title'}
+        </h3>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/annotation/annotation-tool.tsx
+++ b/frontend/src/components/annotation/annotation-tool.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  CircleDot,
+  Waypoints,
+  Paintbrush,
+  Eraser,
+  Palette,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { HexColorPicker } from 'react-colorful';
+
+interface AnnotationToolProps {
+  modelType: string;
+  isActive: boolean;
+  penColor: string;
+  penSize: number;
+  onSelectPen: () => void;
+  onToggleEraser: () => void;
+  onChangePenColor: (color: string) => void;
+  onChangePenSize: (size: number) => void;
+}
+
+const AnnotationTool: React.FC<AnnotationToolProps> = ({
+  modelType,
+  isActive,
+  penColor,
+  penSize,
+  onSelectPen,
+  onToggleEraser,
+  onChangePenColor,
+  onChangePenSize,
+}) => {
+  const [activeTool, setActiveTool] = useState<string | null>('paintbrush');
+  const [penSizeMenuOpen, setPenSizeMenuOpen] = useState(false);
+  const [colorMenuOpen, setColorMenuOpen] = useState(false);
+
+  const sizeMenuRef = useRef<HTMLDivElement>(null);
+  const colorMenuRef = useRef<HTMLDivElement>(null);
+  const sizeButtonRef = useRef<HTMLButtonElement>(null);
+  const paletteButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        sizeMenuRef.current &&
+        !sizeMenuRef.current.contains(target) &&
+        !sizeButtonRef.current?.contains(target)
+      ) {
+        setPenSizeMenuOpen(false);
+      }
+      if (
+        colorMenuRef.current &&
+        !colorMenuRef.current.contains(target) &&
+        !paletteButtonRef.current?.contains(target)
+      ) {
+        setColorMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  if (!isActive) return null;
+
+  const handleSelectTool = (tool: string) => {
+    setActiveTool(tool);
+    if (tool === 'eraser') {
+      onToggleEraser();
+    } else {
+      onSelectPen();
+    }
+  };
+
+  const renderToolButtons = () => {
+    switch (modelType) {
+      case 'CELL':
+        return (
+          <Button
+            variant={'ghost'}
+            size={'icon'}
+            onClick={() => handleSelectTool('circle')}
+            className={activeTool === 'circle' ? 'bg-primary text-white' : ''}
+          >
+            <CircleDot />
+          </Button>
+        );
+      case 'TISSUE':
+      case 'MULTI':
+        return (
+          <>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => handleSelectTool('circle')}
+              className={activeTool === 'circle' ? 'bg-primary text-white' : ''}
+            >
+              <CircleDot />
+            </Button>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => handleSelectTool('waypoints')}
+              className={
+                activeTool === 'waypoints' ? 'bg-primary text-white' : ''
+              }
+            >
+              <Waypoints />
+            </Button>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => handleSelectTool('paintbrush')}
+              className={
+                activeTool === 'paintbrush' ? 'bg-primary text-white' : ''
+              }
+            >
+              <Paintbrush />
+            </Button>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => handleSelectTool('eraser')}
+              className={activeTool === 'eraser' ? 'bg-primary text-white' : ''}
+            >
+              <Eraser />
+            </Button>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="relative flex w-14 flex-col items-center justify-center gap-2 rounded-lg bg-white p-2 shadow">
+      {renderToolButtons()}
+
+      {/* 색상 선택 */}
+      <div className="relative">
+        <Button
+          ref={paletteButtonRef}
+          variant="ghost"
+          size="icon"
+          onClick={() => setColorMenuOpen((prev) => !prev)}
+        >
+          <Palette />
+        </Button>
+        <span
+          className="absolute bottom-1 right-1 h-2 w-2 rounded-full"
+          style={{ backgroundColor: penColor }}
+        />
+        {colorMenuOpen && (
+          <div
+            ref={colorMenuRef}
+            className="absolute bottom-0 left-full z-50 ml-4 rounded-lg bg-white p-4 shadow"
+          >
+            <HexColorPicker
+              color={penColor}
+              onChange={(newColor) => onChangePenColor(newColor)}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 펜 크기 선택 */}
+      <Button
+        ref={sizeButtonRef}
+        variant="ghost"
+        size="icon"
+        onClick={() => setPenSizeMenuOpen((prev) => !prev)}
+      >
+        <SlidersHorizontal />
+      </Button>
+
+      {/* 펜 크기 Preset Dot */}
+      {penSizeMenuOpen && (
+        <div
+          ref={sizeMenuRef}
+          className="absolute bottom-0 left-full z-50 ml-2 flex flex-col items-center gap-3 rounded-lg bg-white p-4 shadow"
+        >
+          {[0.1, 0.3, 0.5, 0.7, 1.0].map((size) => {
+            const isSelected = penSize === size;
+            return (
+              <button
+                key={size}
+                onClick={() => {
+                  onChangePenSize(size); // ✅ 상위에서 관리
+                  setPenSizeMenuOpen(false);
+                }}
+                className={`rounded-full transition-all duration-150 ${
+                  isSelected ? 'ring ring-black ring-offset-2' : ''
+                }`}
+                style={{
+                  width: size + 8,
+                  height: size + 8,
+                  backgroundColor: penColor,
+                  boxSizing: 'content-box',
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AnnotationTool;

--- a/frontend/src/components/annotation/annotation-viewer.tsx
+++ b/frontend/src/components/annotation/annotation-viewer.tsx
@@ -1,0 +1,451 @@
+'use client';
+
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import OpenSeadragon from 'openseadragon';
+import { useOsdviewer } from '@/hooks/use-osdviewer';
+import AnnotationTool from './annotation-tool';
+import ControlPanel from './control-panel';
+import {
+  processPNGImage,
+  syncCanvasWithOSD,
+  redrawCanvas,
+} from '@/utils/canvas-utils';
+import { Stroke, ROI } from '@/utils/canvas-utils';
+import { Button } from '@/components/ui/button';
+
+// ROI 선 두께 상수
+const BORDER_THICKNESS = 2;
+
+const OSDViewer: React.FC<{ modelType: string }> = ({ modelType }) => {
+  /* ================================
+     Ref 및 State 선언
+  ================================== */
+  // 뷰어 및 캔버스 참조
+  const viewerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const viewerInstance = useOsdviewer(viewerRef);
+
+  // PNG 오버레이 이미지 참조
+  const pngImageRef = useRef<HTMLImageElement | null>(null);
+
+  // 드로잉/어노테이션 관련
+  const strokesRef = useRef<Stroke[]>([]);
+  const currentStrokeRef = useRef<Stroke | null>(null);
+  const [isDrawingMode, setIsDrawingMode] = useState<boolean>(false);
+  const [isEraserMode, setIsEraserMode] = useState<boolean>(false);
+  const [penColor, setPenColor] = useState<string>('#000000');
+  const [penSize, setPenSize] = useState<number>(0.5);
+
+  // ROI 관련 상태
+  const [isSelectingROI, setIsSelectingROI] = useState<boolean>(false);
+  const [roi, setROI] = useState<ROI | null>(null);
+  const roiStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  // Undo / Redo 스택
+  const [undoStack, setUndoStack] = useState<Stroke[][]>([]);
+  const [redoStack, setRedoStack] = useState<Stroke[][]>([]);
+  const isRedoingRef = useRef(false);
+
+  // helper: 깊은 복사를 위한 함수 (JSON 방식)
+  const deepCopyStrokes = (strokes: Stroke[]): Stroke[] =>
+    JSON.parse(JSON.stringify(strokes));
+
+  /* ================================
+     캔버스 및 뷰어 동기화
+  ================================== */
+  const redraw = useCallback(() => {
+    if (!viewerInstance.current) return;
+    redrawCanvas(
+      viewerInstance.current,
+      canvasRef,
+      pngImageRef,
+      strokesRef.current,
+      currentStrokeRef.current,
+      roi,
+      isSelectingROI,
+    );
+  }, [viewerInstance, canvasRef, pngImageRef, roi, isSelectingROI]);
+
+  const syncCanvas = useCallback(() => {
+    if (!viewerInstance.current || !canvasRef.current) return;
+    syncCanvasWithOSD(viewerInstance.current, canvasRef, redraw);
+  }, [viewerInstance, canvasRef, redraw]);
+
+  useEffect(() => {
+    if (!viewerInstance.current) return;
+    const updateHandler = () => syncCanvas();
+    viewerInstance.current.addHandler('animation', updateHandler);
+    viewerInstance.current.addHandler('zoom', updateHandler);
+    viewerInstance.current.addHandler('pan', updateHandler);
+    // 초기 동기화
+    syncCanvas();
+
+    window.addEventListener('resize', syncCanvas);
+    return () => window.removeEventListener('resize', syncCanvas);
+  }, [viewerInstance, syncCanvas]);
+
+  /* ================================
+     타일 소스 및 PNG 오버레이 이미지 로드
+  ================================== */
+  useEffect(() => {
+    if (!viewerInstance.current) return;
+    const loadTileSource = async () => {
+      try {
+        const tiffTileSources =
+          await OpenSeadragon.GeoTIFFTileSource.getAllTileSources(
+            '/svs_example.svs',
+          );
+        if (tiffTileSources.length > 0) {
+          viewerInstance.current.addTiledImage({
+            tileSource: tiffTileSources[0],
+          });
+          console.log('타일 소스 추가 완료');
+        }
+      } catch (error) {
+        console.error('타일 소스 로드 실패:', error);
+      }
+    };
+    loadTileSource();
+  }, [viewerInstance]);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    // const img = new Image();
+    // img.src = "/roopy.png"; // public 폴더 내 파일
+    // img.onload = () => processPNGImage(img, pngImageRef, redraw);
+    // img.onerror = () => console.error("PNG 오버레이 이미지 로드 실패");
+  }, [canvasRef, redraw]);
+
+  /* ================================
+     마우스 이벤트 핸들러
+  ================================== */
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current || !viewerInstance.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    if (isSelectingROI) {
+      roiStartRef.current = { x, y };
+      setROI({ x, y, width: 0, height: 0 });
+    } else if (isDrawingMode) {
+      const viewportPoint = viewerInstance.current.viewport.pointFromPixel(
+        new OpenSeadragon.Point(x, y),
+      );
+      currentStrokeRef.current = {
+        points: [{ x: viewportPoint.x, y: viewportPoint.y }],
+        color: isEraserMode ? 'rgba(0,0,0,0)' : penColor,
+        size: penSize,
+        isEraser: isEraserMode,
+      };
+    }
+    redraw();
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current || !viewerInstance.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    if (isSelectingROI && roiStartRef.current) {
+      const start = roiStartRef.current;
+      setROI({
+        x: Math.min(start.x, x),
+        y: Math.min(start.y, y),
+        width: Math.abs(x - start.x),
+        height: Math.abs(y - start.y),
+      });
+    } else if (isDrawingMode && currentStrokeRef.current) {
+      const viewportPoint = viewerInstance.current.viewport.pointFromPixel(
+        new OpenSeadragon.Point(x, y),
+      );
+      currentStrokeRef.current.points.push({
+        x: viewportPoint.x,
+        y: viewportPoint.y,
+      });
+    }
+    redraw();
+  };
+
+  const handleMouseUp = () => {
+    if (!canvasRef.current || !viewerInstance.current) return;
+    const tiledImage = viewerInstance.current.world.getItemAt(0);
+    if (!tiledImage) return;
+
+    if (isSelectingROI) {
+      roiStartRef.current = null;
+      setIsSelectingROI(false);
+      if (roi) {
+        // 조정된 ROI: 테두리 제외
+        const adjustedROI = {
+          x: roi.x + BORDER_THICKNESS,
+          y: roi.y + BORDER_THICKNESS,
+          width: roi.width - 2 * BORDER_THICKNESS,
+          height: roi.height - 2 * BORDER_THICKNESS,
+        };
+        const topLeftViewport = viewerInstance.current.viewport.pointFromPixel(
+          new OpenSeadragon.Point(adjustedROI.x, adjustedROI.y),
+        );
+        const bottomRightViewport =
+          viewerInstance.current.viewport.pointFromPixel(
+            new OpenSeadragon.Point(
+              adjustedROI.x + adjustedROI.width,
+              adjustedROI.y + adjustedROI.height,
+            ),
+          );
+        const topLeftImage =
+          tiledImage.viewportToImageCoordinates(topLeftViewport);
+        const bottomRightImage =
+          tiledImage.viewportToImageCoordinates(bottomRightViewport);
+        const imageROI = {
+          x: Math.round(topLeftImage.x),
+          y: Math.round(topLeftImage.y),
+          width: Math.round(bottomRightImage.x - topLeftImage.x),
+          height: Math.round(bottomRightImage.y - topLeftImage.y),
+        };
+        console.log('ROI (이미지 좌표):', imageROI);
+      }
+    }
+
+    // 드로잉 모드: stroke 저장 및 undo/redo 스택 업데이트
+    if (isDrawingMode && currentStrokeRef.current) {
+      const prevStrokes = deepCopyStrokes(strokesRef.current);
+      setUndoStack((prev) => [...prev, prevStrokes]);
+      setRedoStack([]);
+      strokesRef.current.push(currentStrokeRef.current);
+      currentStrokeRef.current = null;
+    }
+    redraw();
+  };
+
+  const handleSetMove = () => {
+    setIsDrawingMode(false);
+    setIsSelectingROI(false);
+    viewerInstance.current?.setMouseNavEnabled(true);
+  };
+
+  const handleToggleEraser = () => setIsEraserMode((prev) => !prev);
+  const handleSelectPen = () => setIsEraserMode(false);
+
+  // 드로잉 모드 토글 (활성화 시 스택 초기화)
+  const handleToggleAnnotationMode = (): boolean => {
+    if (!isDrawingMode && !roi) {
+      alert('먼저 ROI를 선택하세요.');
+      return false;
+    }
+    if (!isDrawingMode) {
+      setUndoStack([]);
+      setRedoStack([]);
+      setIsDrawingMode(true);
+      setIsSelectingROI(false);
+      viewerInstance.current?.setMouseNavEnabled(false);
+    } else {
+      setIsDrawingMode(false);
+      viewerInstance.current?.setMouseNavEnabled(true);
+    }
+    return true;
+  };
+
+  const handleSelectROI = () => {
+    setIsSelectingROI(true);
+    setIsDrawingMode(false);
+    viewerInstance.current?.setMouseNavEnabled(true);
+  };
+
+  const handleDeleteROI = () => {
+    setUndoStack((prev) => [...prev, deepCopyStrokes(strokesRef.current)]);
+    setRedoStack([]);
+    setROI(null);
+    redraw();
+  };
+
+  const handleReset = () => {
+    setUndoStack((prev) => [...prev, deepCopyStrokes(strokesRef.current)]);
+    setRedoStack([]);
+    strokesRef.current = [];
+    currentStrokeRef.current = null;
+    setROI(null);
+    redraw();
+  };
+
+  const handleUndo = () => {
+    if (undoStack.length === 0) return;
+    const lastState = undoStack[undoStack.length - 1];
+    setRedoStack((prev) => [...prev, deepCopyStrokes(strokesRef.current)]);
+    strokesRef.current = deepCopyStrokes(lastState);
+    setUndoStack((prev) => prev.slice(0, prev.length - 1));
+    redraw();
+  };
+
+  const handleRedo = () => {
+    if (isRedoingRef.current) return;
+    if (redoStack.length === 0) return;
+    isRedoingRef.current = true;
+    const nextState = redoStack[redoStack.length - 1];
+    setUndoStack((prev) => [...prev, deepCopyStrokes(strokesRef.current)]);
+    strokesRef.current = deepCopyStrokes(nextState);
+    setRedoStack((prev) => prev.slice(0, prev.length - 1));
+    redraw();
+    isRedoingRef.current = false;
+  };
+
+  /* ================================
+     동적 분할 개수 계산 및 ROI Export
+  ================================== */
+  const getDivisionCountDynamic = (dimension: number): number => {
+    if (dimension <= 20000) return 1;
+    else if (dimension <= 30000) return 2;
+    else if (dimension <= 40000) return 3;
+    else {
+      return 3 + Math.ceil((dimension - 40000) / 10000);
+    }
+  };
+
+  const exportROIAsPNG = () => {
+    if (!roi || !canvasRef.current || !viewerInstance.current) return;
+    const tiledImage = viewerInstance.current.world.getItemAt(0);
+    if (!tiledImage) return;
+
+    // 조정된 ROI (실선 제외)
+    const adjustedROI = {
+      x: roi.x + BORDER_THICKNESS,
+      y: roi.y + BORDER_THICKNESS,
+      width: roi.width - 2 * BORDER_THICKNESS,
+      height: roi.height - 2 * BORDER_THICKNESS,
+    };
+
+    // 컨테이너 좌표(adjustedROI)를 이미지 좌표로 변환
+    const topLeftViewport = viewerInstance.current.viewport.pointFromPixel(
+      new OpenSeadragon.Point(adjustedROI.x, adjustedROI.y),
+    );
+    const bottomRightViewport = viewerInstance.current.viewport.pointFromPixel(
+      new OpenSeadragon.Point(
+        adjustedROI.x + adjustedROI.width,
+        adjustedROI.y + adjustedROI.height,
+      ),
+    );
+    const topLeftImage = tiledImage.viewportToImageCoordinates(topLeftViewport);
+    const bottomRightImage =
+      tiledImage.viewportToImageCoordinates(bottomRightViewport);
+    const imageROI = {
+      x: Math.round(topLeftImage.x),
+      y: Math.round(topLeftImage.y),
+      width: Math.round(bottomRightImage.x - topLeftImage.x),
+      height: Math.round(bottomRightImage.y - topLeftImage.y),
+    };
+    console.log('Export ROI (이미지 좌표):', imageROI);
+
+    // 전체 export 크기 (이미지 좌표 기준)
+    const totalExportWidth = imageROI.width;
+    const totalExportHeight = imageROI.height;
+
+    // 동적 분할 개수 계산
+    const cols = getDivisionCountDynamic(totalExportWidth);
+    const rows = getDivisionCountDynamic(totalExportHeight);
+
+    // devicePixelRatio 적용
+    const ratio = window.devicePixelRatio || 1;
+
+    // canvas 상의 ROI 영역 (adjustedROI 사용)
+    const sourceROI_X = adjustedROI.x * ratio;
+    const sourceROI_Y = adjustedROI.y * ratio;
+    const sourceROI_W = adjustedROI.width * ratio;
+    const sourceROI_H = adjustedROI.height * ratio;
+
+    // 타일당 출력 크기 (균등 분할)
+    const tileTargetWidth = totalExportWidth / cols;
+    const tileTargetHeight = totalExportHeight / rows;
+
+    // 타일당 canvas 상의 영역 크기 (균등 분할)
+    const sourceTileWidth = sourceROI_W / cols;
+    const sourceTileHeight = sourceROI_H / rows;
+
+    // 각 타일별 이미지 추출 및 저장
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const sourceX = sourceROI_X + c * sourceTileWidth;
+        const sourceY = sourceROI_Y + r * sourceTileHeight;
+
+        const offscreenCanvas = document.createElement('canvas');
+        offscreenCanvas.width = Math.round(tileTargetWidth);
+        offscreenCanvas.height = Math.round(tileTargetHeight);
+        const offCtx = offscreenCanvas.getContext('2d');
+        if (!offCtx) continue;
+
+        offCtx.drawImage(
+          canvasRef.current,
+          sourceX,
+          sourceY,
+          sourceTileWidth,
+          sourceTileHeight,
+          0,
+          0,
+          offscreenCanvas.width,
+          offscreenCanvas.height,
+        );
+
+        offscreenCanvas.toBlob((blob) => {
+          if (!blob) return;
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `${r}_${c}.png`;
+          a.click();
+          URL.revokeObjectURL(url);
+        }, 'image/png');
+      }
+    }
+  };
+
+  /* ================================
+     Render
+  ================================== */
+  return (
+    <div className="flex w-full flex-row items-center justify-between space-x-3 p-10">
+      {isDrawingMode ? (
+        <AnnotationTool
+          modelType={modelType}
+          isActive={isDrawingMode}
+          penColor={penColor}
+          penSize={penSize}
+          onToggleEraser={handleToggleEraser}
+          onSelectPen={handleSelectPen}
+          onChangePenColor={setPenColor}
+          onChangePenSize={setPenSize}
+        />
+      ) : (
+        <div className="flex w-14 flex-col items-center justify-center" />
+      )}
+
+      <div className="relative h-[600px] w-[1000px] bg-white">
+        <div ref={viewerRef} className="h-full w-full" />
+        <canvas
+          ref={canvasRef}
+          className={`absolute left-0 top-0 z-10 ${
+            isDrawingMode || isSelectingROI
+              ? 'pointer-events-auto'
+              : 'pointer-events-none'
+          }`}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseOut={handleMouseUp}
+        />
+      </div>
+
+      <ControlPanel
+        onToggleAnnotationMode={handleToggleAnnotationMode}
+        onSetMove={handleSetMove}
+        onSelectROI={handleSelectROI}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
+        onReset={handleReset}
+      />
+
+      <Button onClick={exportROIAsPNG}>export</Button>
+    </div>
+  );
+};
+
+export default OSDViewer;

--- a/frontend/src/components/annotation/control-panel.tsx
+++ b/frontend/src/components/annotation/control-panel.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import {
+  Move,
+  PenTool,
+  SquareDashedMousePointer,
+  MessageSquare,
+  Undo2,
+  Redo2,
+  Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ControlPanelProps {
+  onToggleAnnotationMode: () => boolean;
+  onSetMove: () => void;
+  onSelectROI: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onReset: () => void;
+}
+
+const ControlPanel: React.FC<ControlPanelProps> = ({
+  onToggleAnnotationMode,
+  onSetMove,
+  onSelectROI,
+  onUndo,
+  onRedo,
+  onReset,
+}) => {
+  // 기본 활성 도구는 "move"로 설정
+  const [activeTool, setActiveTool] = useState<
+    'move' | 'annotation' | 'roiSelect' | 'message' | null
+  >('move');
+
+  // Annotation 버튼 클릭 시 onToggleDrawingMode 호출 후
+  // 성공(true)이면 drawingMode, 실패(false)이면 자동으로 move 버튼 활성화
+  const handleAnnotationModeClick = () => {
+    const success = onToggleAnnotationMode();
+    if (success) {
+      setActiveTool('annotation');
+    } else {
+      setActiveTool('move');
+    }
+  };
+
+  // 단순한 버튼 클릭 시 처리 함수
+  const handleToolClick = (tool: typeof activeTool, callback?: () => void) => {
+    setActiveTool(tool);
+    if (callback) callback();
+  };
+
+  return (
+    <div className="flex h-fit flex-col items-center justify-center gap-2 rounded-lg bg-white p-2 shadow">
+      <Button
+        variant={'ghost'}
+        size={'icon'}
+        onClick={() => handleToolClick('move', onSetMove)}
+        className={activeTool === 'move' ? 'bg-primary text-white' : ''}
+      >
+        <Move />
+      </Button>
+
+      <Button
+        variant={'ghost'}
+        size={'icon'}
+        onClick={handleAnnotationModeClick}
+        className={activeTool === 'annotation' ? 'bg-primary text-white' : ''}
+      >
+        <PenTool />
+      </Button>
+
+      <Button
+        variant={'ghost'}
+        size={'icon'}
+        onClick={() => handleToolClick('roiSelect', onSelectROI)}
+        className={activeTool === 'roiSelect' ? 'bg-primary text-white' : ''}
+      >
+        <SquareDashedMousePointer />
+      </Button>
+
+      <Button
+        variant={'ghost'}
+        size={'icon'}
+        onClick={() => handleToolClick('message')}
+        className={activeTool === 'message' ? 'bg-primary text-white' : ''}
+      >
+        <MessageSquare />
+      </Button>
+
+      {/* 단발성 액션은 toggle state 없이 바로 실행 */}
+      <Button variant={'ghost'} size={'icon'} onClick={onUndo}>
+        <Undo2 />
+      </Button>
+
+      <Button variant={'ghost'} size={'icon'} onClick={onRedo}>
+        <Redo2 />
+      </Button>
+
+      <Button variant={'ghost'} size={'icon'} onClick={onReset}>
+        <Trash2 />
+      </Button>
+    </div>
+  );
+};
+
+export default ControlPanel;

--- a/frontend/src/data/dummy.ts
+++ b/frontend/src/data/dummy.ts
@@ -1,0 +1,136 @@
+import {
+  Project,
+  SubProject,
+  AnnotationHistory,
+  InferenceHistory,
+  Model,
+  ModelType,
+  ROI,
+  TissueAnnotation,
+  CellAnnotation,
+} from '@/types/project-schema';
+
+// 프로젝트 더미 데이터
+export const dummyProjects: Project[] = [
+  {
+    id: 1,
+    title: 'Example Project',
+    description: 'This is an example project description.',
+    thumbnail: 'thumbnail.png',
+    userId: 1,
+    modelId: 5,
+    createdAt: '2025-03-31T12:00:00Z',
+    updatedAt: '2025-03-31T12:00:00Z',
+  },
+  {
+    id: 2,
+    title: 'Another Project',
+    description: 'Another example description.',
+    thumbnail: 'thumbnail2.png',
+    userId: 2,
+    modelId: 6,
+    createdAt: '2025-04-01T12:00:00Z',
+    updatedAt: '2025-04-01T12:00:00Z',
+  },
+];
+
+// 서브프로젝트 더미 데이터 (모델 추론 응답의 subProjectId와 일치)
+export const dummySubProject: SubProject[] = [
+  {
+    id: 42,
+    projectId: '1',
+    svsPath: '/svs_example.svs',
+  },
+  {
+    id: 43,
+    projectId: '1',
+    svsPath: '/svs_example.svs',
+  },
+];
+
+// 어노테이션 히스토리 더미 데이터
+export const dummyAnnotationHistory: AnnotationHistory = {
+  id: 88,
+  subProjectId: 42,
+  modelId: 5,
+  startedAt: '2025-03-31T12:30:00Z',
+  completeAt: '2025-04-01T03:00:00Z',
+};
+
+// 인퍼런스 히스토리 더미 데이터
+export const dummyInferenceHistory: InferenceHistory = {
+  id: 12,
+  accuracy: 0.9375,
+  loss: 0.1642,
+  loopPerformance: 0.82,
+};
+
+// 모델 더미 데이터
+export const dummyModel: Model = {
+  id: 5,
+  annotationHistoryId: 88,
+  name: 'Example Model',
+  modelType: 'CELL' as ModelType,
+  modelVersion: 'v1.0',
+  trainedAt: '2025-03-30T10:00:00Z',
+};
+
+// ROI 더미 데이터 (추후 어노테이션 및 export 기능에 활용)
+export const dummyROI: ROI = {
+  id: 101,
+  annotationHistoryId: 88,
+  x: 120,
+  y: 85,
+  width: 200,
+  height: 200,
+};
+
+// Tissue Annotation 더미 데이터
+export const dummyTissueAnnotation: TissueAnnotation = {
+  id: 1,
+  roiId: 101,
+  imagePath: 'tissue_annotation_image.png',
+};
+
+// Cell Annotation 더미 데이터
+export const dummyCellAnnotation: CellAnnotation = {
+  id: 1,
+  roiId: 101,
+  x: 150,
+  y: 100,
+  radius: 15,
+  color: '#ff0000',
+  label: 'Cell A',
+};
+
+// 모델 추론 결과 응답 더미 데이터
+export const dummyInferenceResult = {
+  inferenceId: 12,
+  annotationHistoryId: 88,
+  subProjectId: 42,
+  modelId: 5,
+  metrics: {
+    accuracy: 0.9375,
+    loss: 0.1642,
+    loopPerformance: 0.82,
+  },
+  completedAt: '2025-04-01T03:14:00Z',
+  results: [
+    {
+      roiId: 101,
+      x: 120,
+      y: 85,
+      width: 200,
+      height: 200,
+      maskUrl: '결과물이미지.png',
+    },
+    {
+      roiId: 102,
+      x: 300,
+      y: 210,
+      width: 180,
+      height: 180,
+      maskUrl: '결과물이미지2.png',
+    },
+  ],
+};

--- a/frontend/src/hooks/use-osdviewer.ts
+++ b/frontend/src/hooks/use-osdviewer.ts
@@ -4,7 +4,7 @@ import { enableGeoTIFFTileSource } from 'geotiff-tilesource';
 
 enableGeoTIFFTileSource(OpenSeadragon);
 
-export const useOSDViewer = (
+export const useOsdviewer = (
   viewerRef: React.RefObject<HTMLDivElement | null>,
 ) => {
   const viewerInstance = useRef<any>(null);

--- a/frontend/src/types/project-schema.ts
+++ b/frontend/src/types/project-schema.ts
@@ -1,0 +1,67 @@
+export interface Project {
+  id: number;
+  title: string;
+  description: string;
+  thumbnail: string;
+  userId: number;
+  modelId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubProject {
+  id: number;
+  projectId: string;
+  svsPath: string;
+}
+
+export interface AnnotationHistory {
+  id: number;
+  subProjectId: number;
+  modelId: number;
+  startedAt: string;
+  completeAt: string;
+}
+
+export interface InferenceHistory {
+  id: number;
+  accuracy: number;
+  loss: number;
+  loopPerformance: number;
+}
+
+export interface Model {
+  id: number;
+  annotationHistoryId: number;
+  name: string;
+  modelType: ModelType;
+  modelVersion: string;
+  trainedAt: string;
+}
+
+export type ModelType = 'CELL' | 'TISSUE' | 'MULTI';
+
+export interface ROI {
+  id: number;
+  annotationHistoryId: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface TissueAnnotation {
+  id: number;
+  roiId: number;
+  imagePath: string;
+}
+
+export interface CellAnnotation {
+  id: number;
+  roiId: number;
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+  label: string;
+}

--- a/frontend/src/utils/canvas-utils.ts
+++ b/frontend/src/utils/canvas-utils.ts
@@ -1,0 +1,215 @@
+import OpenSeadragon from 'openseadragon';
+import React from 'react';
+
+const OSD: any = OpenSeadragon;
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Stroke {
+  points: Point[];
+  color: string;
+  size: number;
+  isEraser?: boolean;
+}
+
+export interface ROI {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const processPNGImage = (
+  img: HTMLImageElement,
+  pngImageRef: React.MutableRefObject<HTMLImageElement | null>,
+  redrawCanvas: () => void,
+) => {
+  const offscreenCanvas = document.createElement('canvas');
+  offscreenCanvas.width = img.width;
+  offscreenCanvas.height = img.height;
+  const offCtx = offscreenCanvas.getContext('2d');
+  if (!offCtx) return;
+  offCtx.drawImage(img, 0, 0);
+  const imageData = offCtx.getImageData(0, 0, img.width, img.height);
+  const data = imageData.data;
+  // 임계값(threshold): R, G, B 모두 20 미만이면 투명하게 처리
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i] < 20 && data[i + 1] < 20 && data[i + 2] < 20) {
+      data[i + 3] = 0;
+    }
+  }
+  offCtx.putImageData(imageData, 0, 0);
+  const processedImg = new Image();
+  processedImg.src = offscreenCanvas.toDataURL();
+  processedImg.onload = () => {
+    pngImageRef.current = processedImg;
+    redrawCanvas();
+  };
+};
+
+export const syncCanvasWithOSD = (
+  viewerInstance: any, // 타입을 any로 지정하여 TS가 내부 멤버를 검사하지 않게 함
+  canvasRef: React.RefObject<HTMLCanvasElement | null>,
+  redrawCanvas: () => void,
+) => {
+  if (!viewerInstance || !canvasRef.current) return;
+  const container = viewerInstance.container;
+  const rect = container.getBoundingClientRect();
+  const ratio = window.devicePixelRatio || 1;
+  const canvas = canvasRef.current;
+  canvas.style.position = 'absolute';
+  canvas.style.top = '0px';
+  canvas.style.left = '0px';
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+  canvas.width = rect.width * ratio;
+  canvas.height = rect.height * ratio;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.resetTransform();
+    ctx.scale(ratio, ratio);
+  }
+  redrawCanvas();
+};
+
+export const redrawCanvas = (
+  viewerInstance: any,
+  canvasRef: React.RefObject<HTMLCanvasElement | null>,
+  pngImageRef: React.MutableRefObject<HTMLImageElement | null>,
+  strokes: Stroke[],
+  currentStroke: Stroke | null,
+  roi: ROI | null,
+  isSelectingROI: boolean,
+) => {
+  if (!canvasRef.current || !viewerInstance) return;
+  const canvas = canvasRef.current;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  // 캔버스 전체 클리어
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const tiledImage = viewerInstance.world.getItemAt(0);
+  if (!tiledImage) {
+    console.warn('tiledImage가 아직 준비되지 않음');
+  }
+
+  // PNG 오버레이 이미지 그리기 (50% 투명도 적용)
+  if (
+    pngImageRef.current &&
+    tiledImage &&
+    typeof tiledImage.getBounds === 'function'
+  ) {
+    const imageViewportRect = tiledImage.getBounds();
+    const topLeft = viewerInstance.viewport.pixelFromPoint(
+      imageViewportRect.getTopLeft(),
+    );
+    const bottomRight = viewerInstance.viewport.pixelFromPoint(
+      imageViewportRect.getBottomRight(),
+    );
+    const overlayX = topLeft.x;
+    const overlayY = topLeft.y;
+    const overlayWidth = bottomRight.x - topLeft.x;
+    const overlayHeight = bottomRight.y - topLeft.y;
+
+    ctx.save();
+    ctx.globalAlpha = 0.6;
+    ctx.drawImage(
+      pngImageRef.current,
+      overlayX,
+      overlayY,
+      overlayWidth,
+      overlayHeight,
+    );
+    ctx.restore();
+  }
+
+  // ROI 클리핑 (ROI가 있을 경우)
+  if (roi) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(roi.x, roi.y, roi.width, roi.height);
+    ctx.clip();
+  }
+
+  // 저장된 stroke들과 현재 stroke 그리기
+  strokes.forEach((stroke) => {
+    drawStroke(stroke, viewerInstance, ctx);
+  });
+  if (currentStroke) {
+    drawStroke(currentStroke, viewerInstance, ctx);
+  }
+
+  if (roi) {
+    ctx.restore();
+  }
+
+  // ROI 영역 테두리: 선택 중이면 점선, 선택 완료면 실선으로 표시
+  if (roi) {
+    ctx.save();
+    ctx.strokeStyle = 'blue';
+    ctx.lineWidth = 2;
+    if (isSelectingROI) {
+      ctx.setLineDash([6, 6]); // 선택 중: 점선
+    } else {
+      ctx.setLineDash([]); // 선택 완료: 실선
+    }
+    ctx.strokeRect(roi.x, roi.y, roi.width, roi.height);
+    ctx.restore();
+  }
+};
+
+const drawStroke = (
+  stroke: Stroke,
+  viewerInstance: any,
+  ctx: CanvasRenderingContext2D,
+) => {
+  if (stroke.points.length === 0) return;
+  ctx.beginPath();
+  const zoom = viewerInstance.viewport.getZoom();
+  const firstPt = stroke.points[0];
+  // 여기서 OpenSeadragon.Point 대신, import한 OSD를 사용합니다.
+  const containerFirstPt = viewerInstance.viewport.pixelFromPoint(
+    new OSD.Point(firstPt.x, firstPt.y),
+  );
+  ctx.moveTo(containerFirstPt.x, containerFirstPt.y);
+
+  if (stroke.points.length === 1) {
+    const radius = (stroke.size * zoom) / 2;
+    ctx.arc(
+      containerFirstPt.x,
+      containerFirstPt.y,
+      radius,
+      0,
+      Math.PI * 2,
+      false,
+    );
+  } else {
+    stroke.points.forEach((pt, idx) => {
+      if (idx === 0) return;
+      const containerPt = viewerInstance.viewport.pixelFromPoint(
+        new OSD.Point(pt.x, pt.y),
+      );
+      ctx.lineTo(containerPt.x, containerPt.y);
+    });
+  }
+
+  if (stroke.isEraser) {
+    ctx.globalCompositeOperation = 'destination-out';
+  } else {
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.strokeStyle = stroke.color;
+  }
+  ctx.lineWidth = stroke.size * zoom;
+  ctx.lineCap = 'round';
+
+  if (stroke.points.length === 1) {
+    ctx.fill();
+  } else {
+    ctx.stroke();
+  }
+  ctx.globalCompositeOperation = 'source-over';
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2563,6 +2563,11 @@ quick-lru@^6.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-6.1.2.tgz#e9a90524108629be35287d0b864e7ad6ceb3659e"
   integrity sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==
 
+react-colorful@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.6.1.tgz#7dc2aed2d7c72fac89694e834d179e32f3da563b"
+  integrity sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==
+
 react-dom@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.0.0.tgz#43446f1f01c65a4cd7f7588083e686a6726cfb57"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #8 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1월부터 3월까지 작업해둔 어노테이션 페이지와 컴포넌트 코드를 옮겼습니다. 피그마 반영해서 Tool 부분 기존과 변경사항 있으며, 사이드바나 헤더에 버튼과 같은 상세 구현은 이루어지지 않은 버전입니다.
백엔드 데이터 스키마 맞춰서 더미 파일 생성해 두었으니 참고 바랍니당:)

### 스크린샷 (선택)
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/632b673f-da4b-47bb-b838-6edaf6637efa" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

1. ROI 생성시 뷰포트 이동
2. ROI 상태관리 수정
3. png export 가능 / import 불가능 문제 해결
4. import 시 png 수정 가능하도록
5. 펜슬 튀는 현상 (픽셀 더 나노단위로)

위 네 가지 문제 해결이 가장 급합니다. 추가적으로 layout 구성 상 상태관리 부분 논의가 필요합니다. 전역적으로 상태관리 하지 않는 선에서 api 연결 시 데이터 요청을 어떻게 효율적으로 보낼 수 있을지 고민이 필요합니다. (나중에 얘기합시다..◠  ◠)