### PR TITLE
[ FE ] fix/#27 roi 에러 해결

### DIFF
--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -125,9 +125,14 @@ const AnnotationViewer: React.FC<{ modelType: string }> = ({ modelType }) => {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
 
+    // 캔버스 좌표를 뷰포트 좌표로 변환
+    const viewportPoint = viewerInstance.current.viewport.pointFromPixel(
+      new OpenSeadragon.Point(x, y),
+    );
+
     if (isSelectingROI) {
-      roiStartRef.current = { x, y };
-      setROI({ x, y, width: 0, height: 0 });
+      roiStartRef.current = viewportPoint; // 뷰포트 좌표 저장
+      setROI({ x: viewportPoint.x, y: viewportPoint.y, width: 0, height: 0 });
     } else if (isDrawingMode) {
       const viewportPoint = viewerInstance.current.viewport.pointFromPixel(
         new OpenSeadragon.Point(x, y),
@@ -148,13 +153,17 @@ const AnnotationViewer: React.FC<{ modelType: string }> = ({ modelType }) => {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
 
+    const viewportPoint = viewerInstance.current.viewport.pointFromPixel(
+      new OpenSeadragon.Point(x, y),
+    );
+
     if (isSelectingROI && roiStartRef.current) {
       const start = roiStartRef.current;
       setROI({
-        x: Math.min(start.x, x),
-        y: Math.min(start.y, y),
-        width: Math.abs(x - start.x),
-        height: Math.abs(y - start.y),
+        x: Math.min(start.x, viewportPoint.x),
+        y: Math.min(start.y, viewportPoint.y),
+        width: Math.abs(viewportPoint.x - start.x),
+        height: Math.abs(viewportPoint.y - start.y),
       });
     } else if (isDrawingMode && currentStrokeRef.current) {
       const viewportPoint = viewerInstance.current.viewport.pointFromPixel(

--- a/frontend/src/utils/canvas-utils.ts
+++ b/frontend/src/utils/canvas-utils.ts
@@ -129,9 +129,21 @@ export const redrawCanvas = (
 
   // ROI 클리핑 (ROI가 있을 경우)
   if (roi) {
+    // 뷰포트 좌표로 저장된 ROI 값을 캔버스 좌표로 변환
+    const topLeft = viewerInstance.viewport.pixelFromPoint(
+      new OpenSeadragon.Point(roi.x, roi.y),
+    );
+    const bottomRight = viewerInstance.viewport.pixelFromPoint(
+      new OpenSeadragon.Point(roi.x + roi.width, roi.y + roi.height),
+    );
+    const clipX = topLeft.x;
+    const clipY = topLeft.y;
+    const clipWidth = bottomRight.x - topLeft.x;
+    const clipHeight = bottomRight.y - topLeft.y;
+
     ctx.save();
     ctx.beginPath();
-    ctx.rect(roi.x, roi.y, roi.width, roi.height);
+    ctx.rect(clipX, clipY, clipWidth, clipHeight);
     ctx.clip();
   }
 
@@ -149,6 +161,15 @@ export const redrawCanvas = (
 
   // ROI 영역 테두리: 선택 중이면 점선, 선택 완료면 실선으로 표시
   if (roi) {
+    const topLeft = viewerInstance.viewport.pixelFromPoint(
+      new OpenSeadragon.Point(roi.x, roi.y),
+    );
+    const bottomRight = viewerInstance.viewport.pixelFromPoint(
+      new OpenSeadragon.Point(roi.x + roi.width, roi.y + roi.height),
+    );
+    const width = bottomRight.x - topLeft.x;
+    const height = bottomRight.y - topLeft.y;
+
     ctx.save();
     ctx.strokeStyle = 'blue';
     ctx.lineWidth = 2;
@@ -157,7 +178,7 @@ export const redrawCanvas = (
     } else {
       ctx.setLineDash([]); // 선택 완료: 실선
     }
-    ctx.strokeRect(roi.x, roi.y, roi.width, roi.height);
+    ctx.strokeRect(topLeft.x, topLeft.y, width, height);
     ctx.restore();
   }
 };

--- a/frontend/src/utils/canvas-utils.ts
+++ b/frontend/src/utils/canvas-utils.ts
@@ -187,7 +187,8 @@ export const redrawCanvas = (
     ctx.lineWidth = 2;
     if (isSelectingROI) ctx.setLineDash([6, 6]);
     else ctx.setLineDash([]);
-    ctx.strokeRect(topLeft.x, topLeft.y, width, height);    ctx.restore();
+    ctx.strokeRect(topLeft.x, topLeft.y, width, height);
+    ctx.restore();
   }
 };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3275,7 +3275,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #27 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

화면을 이동할 때 마다 roi의 위치도 상대적으로 바뀌어야하는데 그 자리에 고정되어있는 에러가 있었습니다.
그래서 기존 캔버스 좌표를 뷰포트 좌표로 변환하였고, export 로직에서는 뷰포트 좌표를 캔버스 좌표로 변환하는 과정을 추가하였습니다.


### 스크린샷 (선택)
<img width="1335" alt="스크린샷 2025-04-06 오후 3 24 42" src="https://github.com/user-attachments/assets/dbec6c3c-7072-4be4-a7c9-5b598533ff37" />

export 한 후 좌표 비교 이미지 입니다.
<img width="567" alt="스크린샷 2025-04-06 오후 3 25 26" src="https://github.com/user-attachments/assets/aca9250d-d73c-435a-8326-17c877d7b12f" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
