### PR TITLE
[ BE ] feat/#46 tissue annoation 저장 api 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,8 +25,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
@@ -1,4 +1,4 @@
-package site.pathos.domain.annotation.tissueAnnotation.entity;
+package site.pathos.domain.annotation.cellAnnotation.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -2,6 +2,7 @@ package site.pathos.domain.annotation.tissueAnnotation.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.pathos.domain.roi.entity.Roi;
@@ -20,5 +21,13 @@ public class TissueAnnotation {
     private Roi roi;
 
     @Column(name = "annoation_image_url", nullable = false)
-    private String annotationImageUrl;
+    private String annotationImagePath;
+
+    @Builder
+    public TissueAnnotation(Roi roi, String annotationImagePath){
+        if (roi == null) throw new IllegalArgumentException("roi cannot be null in TissueAnnotation");
+
+        this.roi = roi;
+        this.annotationImagePath = annotationImagePath;
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -1,4 +1,4 @@
-package site.pathos.domain.annotation.cellAnnotation.entity;
+package site.pathos.domain.annotation.tissueAnnotation.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -16,7 +16,7 @@ public class TissueAnnotation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "roi_id", nullable = false)
     private Roi roi;
 

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -20,7 +20,7 @@ public class TissueAnnotation {
     @JoinColumn(name = "roi_id", nullable = false)
     private Roi roi;
 
-    @Column(name = "annoation_image_url", nullable = false)
+    @Column(name = "annotation_image_url", nullable = false)
     private String annotationImagePath;
 
     @Builder

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/repository/TissueAnnotationRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/repository/TissueAnnotationRepository.java
@@ -1,0 +1,9 @@
+package site.pathos.domain.annotation.tissueAnnotation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.annotation.tissueAnnotation.entity.TissueAnnotation;
+
+@Repository
+public interface TissueAnnotationRepository extends JpaRepository<TissueAnnotation, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
@@ -1,0 +1,83 @@
+package site.pathos.domain.annotation.tissueAnnotation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import site.pathos.domain.annotation.tissueAnnotation.entity.TissueAnnotation;
+import site.pathos.domain.annotation.tissueAnnotation.repository.TissueAnnotationRepository;
+import site.pathos.domain.roi.entity.Roi;
+import site.pathos.domain.roi.repository.RoiRepository;
+import site.pathos.global.aws.s3.S3Service;
+import site.pathos.global.util.ImageUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class TissueAnnotationService {
+
+    private final S3Service s3Service;
+    private final TissueAnnotationRepository tissueAnnotationRepository;
+    private final RoiRepository roiRepository;
+
+    public void uploadTissueAnnotations(Long subProjectId, Long annotationHistoryId, Long roiId, List<MultipartFile> images) {
+        Roi roi = roiRepository.findById(roiId)
+                .orElseThrow(() -> new RuntimeException("ROI not found: " + roiId));
+
+        uploadTiles(subProjectId, annotationHistoryId, roi, images);
+        uploadMergedImage(subProjectId, annotationHistoryId, roi, images);
+    }
+
+    private void uploadTiles(Long subProjectId, Long annotationHistoryId, Roi roi, List<MultipartFile> images) {
+        for (MultipartFile image : images) {
+            String originalFilename = image.getOriginalFilename().replaceAll("\\s+", "_");
+            String key = "sub-project/" + subProjectId
+                    + "/annotation-history/" + annotationHistoryId
+                    + "/roi-" + roi.getId() + "/train/" + originalFilename;
+
+            s3Service.uploadFile(key, image);
+
+            TissueAnnotation ta = TissueAnnotation.builder()
+                    .roi(roi)
+                    .annotationImagePath(key)
+                    .build();
+
+            tissueAnnotationRepository.save(ta);
+        }
+    }
+
+    private void uploadMergedImage(Long subProjectId, Long annotationHistoryId, Roi roi, List<MultipartFile> images) {
+        try {
+            // 1. 병합 대상 이미지 크기 (ROI 기준)
+            int totalWidth = roi.getWidth();
+            int totalHeight = roi.getHeight();
+
+            // 2. 이미지 병합
+            BufferedImage merged = ImageUtils.mergeTiles(images, totalWidth, totalHeight);
+
+            // 3. 업로드할 S3 경로
+            String mergedKey = "sub-project/" + subProjectId
+                    + "/annotation-history/" + annotationHistoryId
+                    + "/roi-" + roi.getId() + "/merged.png";
+
+            // 4. S3에 업로드
+            s3Service.uploadBufferedImage(merged, mergedKey);
+
+            // 5. DB에 TissueAnnotation 저장
+            TissueAnnotation mergedAnnotation = TissueAnnotation.builder()
+                    .roi(roi)
+                    .annotationImagePath(mergedKey)
+                    .build();
+
+            tissueAnnotationRepository.save(mergedAnnotation);
+
+        } catch (Exception e) {
+            throw new RuntimeException("병합 이미지 업로드 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
@@ -1,0 +1,9 @@
+package site.pathos.domain.annotationHistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+
+@Repository
+public interface AnnotationHistoryRepository extends JpaRepository<AnnotationHistory, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
@@ -19,7 +19,7 @@ public class Model {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "annotation_history_id", nullable = false)
+    @JoinColumn(name = "annotation_history_id")
     private AnnotationHistory annotationHistory;
 
     @Column(name = "name", nullable = false)

--- a/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
+++ b/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
@@ -13,13 +13,13 @@ import site.pathos.domain.roi.service.RoiService;
 import java.util.List;
 
 @RestController
-@RequestMapping("Rois")
+@RequestMapping("rois")
 @RequiredArgsConstructor
 public class RoiController {
 
     private final RoiService roiService;
 
-    @PostMapping("/save-rois")
+    @PostMapping
     public ResponseEntity<Void> uploadRois(
             @RequestPart("subProjectId") Long subProjectId,
             @RequestPart("annotationHistoryId") Long annotationHistoryId,

--- a/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
+++ b/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
@@ -1,0 +1,32 @@
+package site.pathos.domain.roi.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import site.pathos.domain.roi.dto.RoiSaveRequestDto;
+import site.pathos.domain.roi.service.RoiService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("Rois")
+@RequiredArgsConstructor
+public class RoiController {
+
+    private final RoiService roiService;
+
+    @PostMapping("/save-rois")
+    public ResponseEntity<Void> uploadRois(
+            @RequestPart("subProjectId") Long subProjectId,
+            @RequestPart("annotationHistoryId") Long annotationHistoryId,
+            @RequestPart("rois") List<RoiSaveRequestDto> rois,
+            @RequestPart("images") List<MultipartFile> images
+    ){
+        roiService.saveWithAnnotations(subProjectId, annotationHistoryId, rois, images);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/roi/dto/RoiSaveRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/RoiSaveRequestDto.java
@@ -1,0 +1,19 @@
+package site.pathos.domain.roi.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class RoiSaveRequestDto {
+
+    private Long roiId; // 기존 ROI면 존재, 없으면 null
+    private Integer x;
+    private Integer y;
+    private Integer width;
+    private Integer height;
+
+    private List<String> imageNames;
+}

--- a/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
+++ b/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
@@ -2,6 +2,7 @@ package site.pathos.domain.roi.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
@@ -31,4 +32,22 @@ public class Roi {
 
     @Column(name = "height", nullable = false)
     private int height;
+
+    @Builder
+    public Roi(AnnotationHistory annotationHistory, int x, int y, int width, int height) {
+        if (annotationHistory == null) throw new IllegalArgumentException("annotationHistory cannot be null");
+
+        this.annotationHistory = annotationHistory;
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    public void changeCoordinates(int x, int y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/roi/repository/RoiRepository.java
+++ b/backend/src/main/java/site/pathos/domain/roi/repository/RoiRepository.java
@@ -1,0 +1,9 @@
+package site.pathos.domain.roi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.roi.entity.Roi;
+
+@Repository
+public interface RoiRepository extends JpaRepository<Roi, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
+++ b/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
@@ -31,7 +31,7 @@ public class RoiService {
         //updated_at 갱신 로직
 
         for(RoiSaveRequestDto roiDto : rois){
-            Roi roi1 = upsertRoi(history, roiDto);
+            Roi roi = upsertRoi(history, roiDto);
 
             // 2. ROI에 해당하는 이미지 리스트 추출
             List<MultipartFile> matchedImages = images.stream()
@@ -42,7 +42,7 @@ public class RoiService {
             tissueAnnotationService.uploadTissueAnnotations(
                     subProjectId,
                     annotationHistoryId,
-                    roiDto.getRoiId(),
+                    roi.getId(),
                     matchedImages
             );
         }

--- a/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
+++ b/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
@@ -1,0 +1,75 @@
+package site.pathos.domain.roi.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent.FutureOrPresentValidatorForInstant;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import site.pathos.domain.annotation.tissueAnnotation.service.TissueAnnotationService;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
+import site.pathos.domain.roi.dto.RoiSaveRequestDto;
+import site.pathos.domain.roi.entity.Roi;
+import site.pathos.domain.roi.repository.RoiRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoiService {
+
+    private final AnnotationHistoryRepository annotationHistoryRepository;
+    private final RoiRepository roiRepository;
+    private final TissueAnnotationService tissueAnnotationService;
+
+    @Transactional
+    public void saveWithAnnotations(Long subProjectId, Long annotationHistoryId, List<RoiSaveRequestDto> rois, List<MultipartFile> images) {
+        AnnotationHistory history = annotationHistoryRepository.findById(annotationHistoryId)
+                .orElseThrow(() -> new IllegalArgumentException("AnnotationHistory not found"));
+
+        //TODO
+        //updated_at 갱신 로직
+
+        for(RoiSaveRequestDto roiDto : rois){
+            Roi roi1 = upsertRoi(history, roiDto);
+
+            // 2. ROI에 해당하는 이미지 리스트 추출
+            List<MultipartFile> matchedImages = images.stream()
+                    .filter(img -> roiDto.getImageNames().contains(img.getOriginalFilename()))
+                    .toList();
+
+            // 3. 해당 ROI에 대한 TissueAnnotation 저장 및 S3 업로드
+            tissueAnnotationService.uploadTissueAnnotations(
+                    subProjectId,
+                    annotationHistoryId,
+                    roiDto.getRoiId(),
+                    matchedImages
+            );
+        }
+    }
+
+    private Roi upsertRoi(AnnotationHistory history, RoiSaveRequestDto roiDto) {
+        if (roiDto.getRoiId() != null) {
+            //기존에 존재하던 roi를 수정한 경우
+            Roi roi = roiRepository.findById(roiDto.getRoiId())
+                    .orElseThrow(() -> new RuntimeException("ROI not found: " + roiDto.getRoiId()));
+            roi.changeCoordinates(
+                    roiDto.getX(),
+                    roiDto.getY(),
+                    roiDto.getWidth(),
+                    roiDto.getHeight()
+            );
+            return roi;
+        } else {
+            //새로 생긴 roi의 경우
+            Roi roi = Roi.builder()
+                    .annotationHistory(history)
+                    .x(roiDto.getX())
+                    .y(roiDto.getY())
+                    .width(roiDto.getWidth())
+                    .height(roiDto.getHeight())
+                    .build();
+            return roiRepository.save(roi);
+        }
+    }
+}

--- a/backend/src/main/java/site/pathos/global/aws/s3/AmazonS3Configuration.java
+++ b/backend/src/main/java/site/pathos/global/aws/s3/AmazonS3Configuration.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
@@ -37,13 +38,22 @@ public class AmazonS3Configuration {
     }
 
     @Bean
-    public S3AsyncClient amazonS3Client(
+    public S3AsyncClient S3ClientAsync(
             StaticCredentialsProvider awsCredentialsProvider,
             Region awsRegion
     ) {
         return S3CrtAsyncClient.builder()
                 .credentialsProvider(awsCredentialsProvider)
                 .region(awsRegion)
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client(StaticCredentialsProvider credentialsProvider,
+                             Region region) {
+        return S3Client.builder()
+                .region(region)
+                .credentialsProvider(credentialsProvider)
                 .build();
     }
 

--- a/backend/src/main/java/site/pathos/global/aws/s3/S3Service.java
+++ b/backend/src/main/java/site/pathos/global/aws/s3/S3Service.java
@@ -5,13 +5,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import site.pathos.global.util.ImageUtils;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -20,34 +28,42 @@ import java.util.concurrent.Executors;
 @Service
 @RequiredArgsConstructor
 public class S3Service {
-    private final S3AsyncClient amazonS3Client;
+    private final S3Client s3Client;
     private final AwsProperty awsProperty;
     private final S3Presigner s3Presigner;
 
     public void uploadFile(String key, MultipartFile file) {
         try {
             PutObjectRequest request = PutObjectRequest.builder()
-                    .bucket(awsProperty.region())
+                    .bucket(awsProperty.s3().bucket())
                     .key(key)
                     .contentType(file.getContentType())
                     .build();
 
-            CompletableFuture<Void> future = amazonS3Client.putObject(
+            s3Client.putObject(
                     request,
-                    AsyncRequestBody.fromInputStream(file.getInputStream(), file.getSize(), Executors.newSingleThreadExecutor())
-            ).thenAccept(response -> {
-                log.info("파일 업로드 완료: {}", key);
-            }).exceptionally(ex -> {
-                log.error("업로드 실패: {}", ex.getMessage(), ex);
-                return null;
-            });
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
 
-            future.join();
-
-        } catch (Exception e) {
-            log.error("업로드 중 예외 발생", e);
-            throw new RuntimeException(e);
+            log.info("S3 업로드 완료: {}", key);
+        } catch (IOException e) {
+            log.error("S3 업로드 중 오류 발생", e);
+            throw new RuntimeException("S3 업로드 실패", e);
         }
+    }
+
+    public String uploadBufferedImage(BufferedImage image, String filename) {
+        byte[] imageBytes = ImageUtils.convertToByteArray(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(awsProperty.s3().bucket()) // bucket 이름 가져오기
+                .key(filename)
+                .contentType("image/png")
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(imageBytes));
+
+        return filename;
     }
 
     public String getPresignedUrl(String key) {

--- a/backend/src/main/java/site/pathos/global/util/ImageUtils.java
+++ b/backend/src/main/java/site/pathos/global/util/ImageUtils.java
@@ -1,0 +1,89 @@
+package site.pathos.global.util;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImageUtils {
+
+    public static byte[] convertToByteArray(BufferedImage image) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", baos);
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 변환 실패", e);
+        }
+    }
+
+    public static BufferedImage mergeTiles(List<MultipartFile> imageFiles, int width, int height) throws IOException {
+        BufferedImage mergedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = mergedImage.createGraphics();
+
+        for (MultipartFile file : imageFiles) {
+            String[] parts = file.getOriginalFilename().replace(".png", "").split("_");
+            int row = Integer.parseInt(parts[2]);
+            int col = Integer.parseInt(parts[3]);
+
+            BufferedImage tile = ImageIO.read(file.getInputStream());
+
+            int tileWidth = tile.getWidth();
+            int tileHeight = tile.getHeight();
+
+            int x = col * tileWidth;
+            int y = row * tileHeight;
+
+            g2d.drawImage(tile, x, y, null);
+        }
+
+        g2d.dispose();
+        return mergedImage;
+    }
+
+    public static int getDivisionCountDynamic(int dimension) {
+        if (dimension <= 20000) return 1;
+        else if (dimension <= 30000) return 2;
+        else if (dimension <= 40000) return 3;
+        else return 3 + (int) Math.ceil((dimension - 40000) / 10000.0);
+    }
+
+    // 이미지 자르기 메서드
+    public static List<BufferedImage> sliceImageByROI(BufferedImage image, int roiX, int roiY, int roiWidth, int roiHeight) {
+        List<BufferedImage> tiles = new ArrayList<>();
+
+        int cols = getDivisionCountDynamic(roiWidth);
+        int rows = getDivisionCountDynamic(roiHeight);
+
+        int baseTileWidth = roiWidth / cols;
+        int baseTileHeight = roiHeight / rows;
+
+        int widthRemainder = roiWidth % cols;
+        int heightRemainder = roiHeight % rows;
+
+        int yOffset = roiY;
+
+        for (int row = 0; row < rows; row++) {
+            int tileHeight = baseTileHeight + (row < heightRemainder ? 1 : 0);
+            int xOffset = roiX;
+
+            for (int col = 0; col < cols; col++) {
+                int tileWidth = baseTileWidth + (col < widthRemainder ? 1 : 0);
+
+                BufferedImage tile = image.getSubimage(xOffset, yOffset, tileWidth, tileHeight);
+                tiles.add(tile);
+
+                xOffset += tileWidth;
+            }
+
+            yOffset += tileHeight;
+        }
+
+        return tiles;
+    }
+}

--- a/backend/src/main/java/site/pathos/global/util/ImageUtils.java
+++ b/backend/src/main/java/site/pathos/global/util/ImageUtils.java
@@ -28,8 +28,8 @@ public class ImageUtils {
 
         for (MultipartFile file : imageFiles) {
             String[] parts = file.getOriginalFilename().replace(".png", "").split("_");
-            int row = Integer.parseInt(parts[2]);
-            int col = Integer.parseInt(parts[3]);
+            int row = Integer.parseInt(parts[parts.length - 2]);
+            int col = Integer.parseInt(parts[parts.length - 1]);
 
             BufferedImage tile = ImageIO.read(file.getInputStream());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호 

- Closes #46 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 기본 제공되는 Model의 경우 annotationHistoryId가 없기 때문에 null이 가능하도록 변경하였습니다.
- tissueAnnotation을 프론트와 모델서버에 각각 잘린이미지, 전체이미지로 보내주어야해서 관계를 1:1 -> 1:n으로 변경했습니다.
- 우선 테스트를 위해 동기처리로 구현하였으나 추후에 s3Async를 활용하여 비동기 처리를 해야할 필요가 있어보입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
