### PR TITLE
[ FE ] feat/#43 어노테이션 페이지 퍼블리싱

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-select": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",

--- a/frontend/src/app/main/layout.tsx
+++ b/frontend/src/app/main/layout.tsx
@@ -15,12 +15,12 @@ export default function MainLayout({
   // /main/projects/annotation/ 경로일 경우 사이드바를 숨김
   const hideSidebar = pathname.startsWith('/main/projects/annotation/');
 
-  return (
-    <div>
-      <SidebarProvider open={!hideSidebar}>
-        {!hideSidebar && <AppSidebar />}
-        <main>{children}</main>
-      </SidebarProvider>
-    </div>
+  return hideSidebar ? (
+    <main>{children}</main>
+  ) : (
+    <SidebarProvider open>
+      <AppSidebar />
+      <main>{children}</main>
+    </SidebarProvider>
   );
 }

--- a/frontend/src/app/main/projects/annotation/[id]/layout.tsx
+++ b/frontend/src/app/main/projects/annotation/[id]/layout.tsx
@@ -6,7 +6,7 @@ export default function AnnotationLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex h-screen w-full flex-col gap-20 overflow-hidden overscroll-none">
+    <div className="flex h-screen w-full flex-col gap-16 overflow-hidden overscroll-none">
       <div className="sticky top-0 z-10">
         <AnnotationHeader />
       </div>

--- a/frontend/src/app/main/projects/annotation/[id]/page.tsx
+++ b/frontend/src/app/main/projects/annotation/[id]/page.tsx
@@ -51,7 +51,7 @@ export default function ProjectAnnotationPage() {
     return <p>이 프로젝트에는 서브프로젝트가 없습니다.</p>;
 
   return (
-    <div className="space-y-4 p-6">
+    <div>
       {/* 선택된 서브프로젝트가 있을 때만 뷰어 표시 */}
       {selected ? (
         <AnnotationViewer
@@ -62,20 +62,20 @@ export default function ProjectAnnotationPage() {
         <p>서브프로젝트를 선택하세요.</p>
       )}
 
-      {/* 서브프로젝트 선택 버튼 */}
-      <div className="mt-20 flex gap-2">
-        {subProjects.map((sp) => (
-          <button
-            key={sp.id}
-            className={`rounded border px-3 py-1 ${
-              selected?.id === sp.id ? 'bg-blue-600 text-white' : 'bg-white'
-            }`}
-            onClick={() => setSelected(sp)}
-          >
-            Sub #{sp.id}
-          </button>
-        ))}
-      </div>
+      {/*/!* 서브프로젝트 선택 버튼 *!/*/}
+      {/*<div className="mt-20 flex gap-2">*/}
+      {/*  {subProjects.map((sp) => (*/}
+      {/*    <button*/}
+      {/*      key={sp.id}*/}
+      {/*      className={`rounded border px-3 py-1 ${*/}
+      {/*        selected?.id === sp.id ? 'bg-blue-600 text-white' : 'bg-white'*/}
+      {/*      }`}*/}
+      {/*      onClick={() => setSelected(sp)}*/}
+      {/*    >*/}
+      {/*      Sub #{sp.id}*/}
+      {/*    </button>*/}
+      {/*  ))}*/}
+      {/*</div>*/}
     </div>
   );
 }

--- a/frontend/src/components/annotation/annotation-header/index.tsx
+++ b/frontend/src/components/annotation/annotation-header/index.tsx
@@ -3,18 +3,36 @@
 import { useRouter, useParams } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { dummyProjects } from '@/data/dummy';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { formatDateTime } from '@/lib/utils';
 
 export default function AnnotationHeader() {
   const router = useRouter();
   const { id } = useParams(); // 현재 프로젝트 ID 가져오기
 
-  if (!id) return null; // ID가 없으면 렌더링하지 않음
+  if (!id) return null;
 
-  // dummyProjects 배열에서 현재 id와 일치하는 프로젝트 찾기
   const project = dummyProjects.find((proj) => proj.id === Number(id));
 
+  // 가장 최근 버전 기록 찾기 (startedAt 기준 내림차순 정렬 후 첫 번째)
+  const latestHistory = project?.history
+    ?.slice()
+    .sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    )[0];
+
   return (
-    <div className="bg-primary fixed right-0 top-0 w-full border-b border-white p-4 text-white">
+    <div className="bg-primary fixed right-0 top-0 flex w-full flex-row items-center justify-between p-4 text-white">
+      {/* 왼쪽: 뒤로가기 + 프로젝트 제목 */}
       <div className="flex flex-row items-center gap-4">
         <button onClick={() => router.push('/main/projects')}>
           <ArrowLeft className="text-white" />
@@ -22,6 +40,83 @@ export default function AnnotationHeader() {
         <h3 className="text-lg font-semibold">
           {project ? project.title : 'Project Title'}
         </h3>
+      </div>
+
+      {/* 오른쪽: 모델 정보 */}
+      <div className="flex flex-row items-center gap-4">
+        {/* 모델 버전 기록 (가장 최근 히스토리) */}
+        <Select value={latestHistory?.id.toString()} onValueChange={() => {}}>
+          <SelectTrigger>
+            <SelectValue>
+              {latestHistory
+                ? (() => {
+                    const { full, time } = formatDateTime(
+                      latestHistory.startedAt,
+                    );
+                    return (
+                      <div className="flex flex-row items-center gap-2">
+                        <span>Version {latestHistory.id}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {full} {time}
+                        </span>
+                      </div>
+                    );
+                  })()
+                : 'Version Select'}
+            </SelectValue>
+          </SelectTrigger>
+
+          <SelectContent>
+            {project?.history
+              ?.slice() // 원본 보호
+              .sort(
+                (a, b) =>
+                  new Date(b.startedAt).getTime() -
+                  new Date(a.startedAt).getTime(),
+              )
+              .map((h) => {
+                const { full, time } = formatDateTime(h.startedAt);
+                return (
+                  <SelectItem key={h.id} value={h.id.toString()}>
+                    <div className="flex flex-col">
+                      <span>Version {h.id}</span>
+                      <span className="text-muted-foreground text-xs">
+                        {full} {time}
+                      </span>
+                    </div>
+                  </SelectItem>
+                );
+              })}
+          </SelectContent>
+        </Select>
+
+        {/* 모델 타입 */}
+        <Select
+          value={project?.modelType.toLowerCase()}
+          onValueChange={() => {}}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="모델 타입 선택" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="cell">Cell</SelectItem>
+            <SelectItem value="tissue">Tissue</SelectItem>
+            <SelectItem value="multi">Multi</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* 모델 이름 */}
+        <Input
+          className="w-32 text-lg font-medium"
+          value={project?.modelName ?? ''}
+          placeholder="모델 이름을 입력하세요"
+          readOnly
+        />
+
+        {/* 버튼 */}
+        <Button variant="secondary">Train</Button>
+        <Button variant="secondary">Run</Button>
+        <Button variant="secondary">Save</Button>
       </div>
     </div>
   );

--- a/frontend/src/components/annotation/annotation-sidebar/index.tsx
+++ b/frontend/src/components/annotation/annotation-sidebar/index.tsx
@@ -1,0 +1,3 @@
+export default function AnnotationSidebar() {
+  return <div className="w-110 h-full bg-blue-500"> 사이드바 </div>;
+}

--- a/frontend/src/components/annotation/annotation-subproject-slider/index.tsx
+++ b/frontend/src/components/annotation/annotation-subproject-slider/index.tsx
@@ -1,0 +1,5 @@
+export default function AnnotationSubProjectSlider() {
+  return (
+    <div className="h-full w-full bg-red-500"> 서브프로젝트 슬라이더 </div>
+  );
+}

--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -574,7 +574,7 @@ const AnnotationViewer: React.FC<{
           ) : (
             <div className="flex w-14 flex-col items-center justify-center" />
           )}
-          <div className="relative h-[600px] w-[1000px] bg-white">
+          <div className="relative h-[550px] w-[900px] border bg-white">
             <div ref={viewerRef} className="absolute z-0 h-full w-full" />
             <canvas
               ref={canvasRef}

--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -46,7 +46,6 @@ const AnnotationViewer: React.FC<{
   const strokesRef = useRef<Stroke[]>([]);
   const currentStrokeRef = useRef<Stroke | null>(null);
   const [isDrawingMode, setIsDrawingMode] = useState<boolean>(false);
-  const [isEraserMode, setIsEraserMode] = useState<boolean>(false);
   const [penColor, setPenColor] = useState<string>('#FF0000');
   const [penSize, setPenSize] = useState<number>(10);
 
@@ -389,6 +388,9 @@ const AnnotationViewer: React.FC<{
       ctx.save();
       drawStroke(currentStrokeRef.current, viewerInstance.current, ctx);
       ctx.restore();
+    } else if (activeTool === 'polygon') {
+      setMousePosition(viewportPoint);
+      redraw();
     }
   };
 

--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -21,6 +21,8 @@ import { Point, Stroke, ROI, LoadedROI } from '@/types/annotation';
 import { Button } from '@/components/ui/button';
 import { SubProject } from '@/types/project-schema';
 import { dummyInferenceResult } from '@/data/dummy';
+import AnnotationSidebar from '@/components/annotation/annotation-sidebar';
+import AnnotationSubProjectSlider from '@/components/annotation/annotation-subproject-slider';
 
 // ROI 선 두께 상수
 const BORDER_THICKNESS = 2;
@@ -466,56 +468,64 @@ const AnnotationViewer: React.FC<{
      Render
   ================================== */
   return (
-    <div className="flex w-full flex-row items-center justify-between space-x-3 p-10">
-      {isDrawingMode ? (
-        <AnnotationTool
-          modelType={modelType}
-          isActive={isDrawingMode}
-          penColor={penColor}
-          penSize={penSize}
-          onToggleEraser={handleToggleEraser}
-          onSelectPen={handleSelectPen}
-          onChangePenColor={setPenColor}
-          onChangePenSize={setPenSize}
-        />
-      ) : (
-        <div className="flex w-14 flex-col items-center justify-center" />
-      )}
-      <div className="relative h-[600px] w-[1000px] bg-white">
-        <div ref={viewerRef} className="absolute z-0 h-full w-full" />
-        <canvas
-          ref={canvasRef}
-          className={`absolute inset-0 z-10 ${
-            isDrawingMode || isSelectingROI
-              ? 'pointer-events-auto'
-              : 'pointer-events-none'
-          }`}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseOut={handleMouseUp}
-        />
-        <canvas
-          ref={roiCanvasRef}
-          className="pointer-events-none absolute inset-0 z-20"
-        />
+    <div className="flex h-screen w-full flex-row">
+      <AnnotationSidebar />
+
+      <div className="flex w-full flex-col">
+        <div className="my-10 flex w-full flex-row items-center justify-between space-x-3 px-10">
+          {isDrawingMode ? (
+            <AnnotationTool
+              modelType={modelType}
+              isActive={isDrawingMode}
+              penColor={penColor}
+              penSize={penSize}
+              onToggleEraser={handleToggleEraser}
+              onSelectPen={handleSelectPen}
+              onChangePenColor={setPenColor}
+              onChangePenSize={setPenSize}
+            />
+          ) : (
+            <div className="flex w-14 flex-col items-center justify-center" />
+          )}
+          <div className="relative h-[550px] w-[900px] border bg-white">
+            <div ref={viewerRef} className="absolute z-0 h-full w-full" />
+            <canvas
+              ref={canvasRef}
+              className={`absolute inset-0 z-10 ${
+                isDrawingMode || isSelectingROI
+                  ? 'pointer-events-auto'
+                  : 'pointer-events-none'
+              }`}
+              onMouseDown={handleMouseDown}
+              onMouseMove={handleMouseMove}
+              onMouseUp={handleMouseUp}
+              onMouseOut={handleMouseUp}
+            />
+            <canvas
+              ref={roiCanvasRef}
+              className="pointer-events-none absolute inset-0 z-20"
+            />
+          </div>
+          <AnnotationControlPanel
+            onToggleAnnotationMode={handleToggleAnnotationMode}
+            onSetMove={handleSetMove}
+            onSelectROI={handleSelectROI}
+            onUndo={handleUndo}
+            onRedo={handleRedo}
+            onReset={handleReset}
+          />
+          {/*<Button*/}
+          {/*  onClick={() => {*/}
+          {/*    if (!viewerInstance.current || !canvasRef.current || !roi) return;*/}
+          {/*    exportROIAsPNG(viewerInstance.current, canvasRef.current, roi);*/}
+          {/*  }}*/}
+          {/*>*/}
+          {/*  Export*/}
+          {/*</Button>{' '}*/}
+        </div>
+
+        <AnnotationSubProjectSlider />
       </div>
-      <AnnotationControlPanel
-        onToggleAnnotationMode={handleToggleAnnotationMode}
-        onSetMove={handleSetMove}
-        onSelectROI={handleSelectROI}
-        onUndo={handleUndo}
-        onRedo={handleRedo}
-        onReset={handleReset}
-      />
-      <Button
-        onClick={() => {
-          if (!viewerInstance.current || !canvasRef.current || !roi) return;
-          exportROIAsPNG(viewerInstance.current, canvasRef.current, roi);
-        }}
-      >
-        Export
-      </Button>{' '}
     </div>
   );
 };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) relative z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border shadow-md',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      <span className="size-3.5 absolute right-2 flex items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/frontend/src/data/dummy.ts
+++ b/frontend/src/data/dummy.ts
@@ -10,6 +10,24 @@ import {
   CellAnnotation,
 } from '@/types/project-schema';
 
+// 어노테이션 히스토리 더미 데이터 (배열로 변경)
+export const dummyAnnotationHistory: AnnotationHistory[] = [
+  {
+    id: 88,
+    subProjectId: 42,
+    modelId: 5,
+    startedAt: '2025-03-31T12:30:00Z',
+    completeAt: '2025-04-01T03:00:00Z',
+  },
+  {
+    id: 89,
+    subProjectId: 42,
+    modelId: 5,
+    startedAt: '2025-04-01T13:00:00Z',
+    completeAt: '2025-04-01T14:00:00Z',
+  },
+];
+
 // 프로젝트 더미 데이터
 export const dummyProjects: Project[] = [
   {
@@ -21,6 +39,9 @@ export const dummyProjects: Project[] = [
     modelId: 5,
     createdAt: '2025-03-31T12:00:00Z',
     updatedAt: '2025-03-31T12:00:00Z',
+    history: dummyAnnotationHistory,
+    modelType: 'TISSUE' as ModelType,
+    modelName: 'Example Model',
   },
   {
     id: 2,
@@ -31,6 +52,9 @@ export const dummyProjects: Project[] = [
     modelId: 6,
     createdAt: '2025-04-01T12:00:00Z',
     updatedAt: '2025-04-01T12:00:00Z',
+    history: dummyAnnotationHistory,
+    modelType: 'MULTI' as ModelType,
+    modelName: 'Example Model2',
   },
 ];
 
@@ -47,15 +71,6 @@ export const dummySubProject: SubProject[] = [
     svsPath: '/svs_example.svs',
   },
 ];
-
-// 어노테이션 히스토리 더미 데이터
-export const dummyAnnotationHistory: AnnotationHistory = {
-  id: 88,
-  subProjectId: 42,
-  modelId: 5,
-  startedAt: '2025-03-31T12:30:00Z',
-  completeAt: '2025-04-01T03:00:00Z',
-};
 
 // 인퍼런스 히스토리 더미 데이터
 export const dummyInferenceHistory: InferenceHistory = {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const formatDateTime = (dateStr: string) => {
+  const date = new Date(dateStr);
+
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+
+  const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const dayOfWeek = dayNames[date.getDay()];
+
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+
+  return {
+    full: `${year}. ${month}. ${day} (${dayOfWeek})`,
+    time: `${hours}:${minutes}`,
+  };
+};

--- a/frontend/src/types/project-schema.ts
+++ b/frontend/src/types/project-schema.ts
@@ -7,6 +7,9 @@ export interface Project {
   modelId: number;
   createdAt: string;
   updatedAt: string;
+  history: AnnotationHistory[];
+  modelType: ModelType;
+  modelName: string;
 }
 
 export interface SubProject {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -389,10 +389,20 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
+"@radix-ui/number@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.1.1.tgz#7b2c9225fbf1b126539551f5985769d0048d9090"
+  integrity sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==
+
 "@radix-ui/primitive@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
   integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
+"@radix-ui/primitive@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.2.tgz#83f415c4425f21e3d27914c12b3272a32e3dae65"
+  integrity sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==
 
 "@radix-ui/react-arrow@1.1.2":
   version "1.1.2"
@@ -400,6 +410,13 @@
   integrity sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==
   dependencies:
     "@radix-ui/react-primitive" "2.0.2"
+
+"@radix-ui/react-arrow@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.3.tgz#8926eb1d87f73c2e047eac96703949f168c85861"
+  integrity sha512-2dvVU4jva0qkNZH6HHWuSz5FN5GeU5tymvCgutF8WaXz9WnD1NgUhy73cqzkjkN4Zkn8lfTPv5JIfrC221W+Nw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.3"
 
 "@radix-ui/react-collapsible@^1.1.3":
   version "1.1.3"
@@ -415,15 +432,35 @@
     "@radix-ui/react-use-controllable-state" "1.1.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-collection@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.3.tgz#cfd46dcea5a8ab064d91798feeb46faba4032930"
+  integrity sha512-mM2pxoQw5HJ49rkzwOs7Y6J4oYH22wS8BfK2/bBxROlI4xuR0c4jEenQP63LlTlDkO6Buj2Vt+QYAYcOgqtrXA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-slot" "1.2.0"
+
 "@radix-ui/react-compose-refs@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
   integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
 
+"@radix-ui/react-compose-refs@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
 "@radix-ui/react-context@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
   integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
 "@radix-ui/react-dialog@^1.1.6":
   version "1.1.6"
@@ -445,6 +482,11 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-direction@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
+  integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
+
 "@radix-ui/react-dismissable-layer@1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz#96dde2be078c694a621e55e047406c58cd5fe774"
@@ -456,10 +498,26 @@
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
+"@radix-ui/react-dismissable-layer@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.6.tgz#e72c156cac7b07614fe8e3a039ab7081ce413686"
+  integrity sha512-7gpgMT2gyKym9Jz2ZhlRXSg2y6cNQIK8d/cqBZ0RBCaps8pFryCWXiUKI+uHGFrhMrbGUP7U6PWgiXzIxoyF3Q==
+  dependencies:
+    "@radix-ui/primitive" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-escape-keydown" "1.1.1"
+
 "@radix-ui/react-focus-guards@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz#8635edd346304f8b42cae86b05912b61aef27afe"
   integrity sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==
+
+"@radix-ui/react-focus-guards@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz#4ec9a7e50925f7fb661394460045b46212a33bed"
+  integrity sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==
 
 "@radix-ui/react-focus-scope@1.1.2":
   version "1.1.2"
@@ -470,12 +528,28 @@
     "@radix-ui/react-primitive" "2.0.2"
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
+"@radix-ui/react-focus-scope@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.3.tgz#eac83a3aac700db17650b41b30724deffac5b28a"
+  integrity sha512-4XaDlq0bPt7oJwR+0k0clCiCO/7lO7NKZTAaJBYxDNQT/vj4ig0/UvctrRscZaFREpRvUTkpKR96ov1e6jptQg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
 "@radix-ui/react-id@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.0.tgz#de47339656594ad722eb87f94a6b25f9cffae0ed"
   integrity sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-id@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-popper@1.2.2":
   version "1.2.2"
@@ -493,6 +567,22 @@
     "@radix-ui/react-use-size" "1.1.0"
     "@radix-ui/rect" "1.1.0"
 
+"@radix-ui/react-popper@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.3.tgz#3b6ef3388fd209bb46341e1e40125b75f07f1304"
+  integrity sha512-iNb9LYUMkne9zIahukgQmHlSBp9XWGeQQ7FvUGNk45ywzOb6kQa+Ca38OphXlWDiKvyneo9S+KSJsLfLt8812A==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-rect" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+    "@radix-ui/rect" "1.1.1"
+
 "@radix-ui/react-portal@1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.4.tgz#ff5401ff63c8a825c46eea96d3aef66074b8c0c8"
@@ -500,6 +590,14 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.2"
     "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-portal@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.5.tgz#50ed6bee2d895c9a9dfc28625f24b8483b74d431"
+  integrity sha512-ps/67ZqsFm+Mb6lSPJpfhRLrVL2i2fntgCmGMqqth4eaGUf+knAuuRtWVJrNjUhExgmdRqftSgzpf0DF0n6yXA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-presence@1.1.2":
   version "1.1.2"
@@ -516,6 +614,40 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.2"
 
+"@radix-ui/react-primitive@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.3.tgz#13c654dc4754558870a9c769f6febe5980a1bad8"
+  integrity sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.0"
+
+"@radix-ui/react-select@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-2.1.7.tgz#68561488ca54cad07352b3f2c2d29e0da28bbaa0"
+  integrity sha512-exzGIRtc7S8EIM2KjFg+7lJZsH7O7tpaBaJbBNVDnOZNhtoQ2iV+iSNfi2Wth0m6h3trJkMVvzAehB3c6xj/3Q==
+  dependencies:
+    "@radix-ui/number" "1.1.1"
+    "@radix-ui/primitive" "1.1.2"
+    "@radix-ui/react-collection" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.6"
+    "@radix-ui/react-focus-guards" "1.1.2"
+    "@radix-ui/react-focus-scope" "1.1.3"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.3"
+    "@radix-ui/react-portal" "1.1.5"
+    "@radix-ui/react-primitive" "2.0.3"
+    "@radix-ui/react-slot" "1.2.0"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-visually-hidden" "1.1.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
 "@radix-ui/react-separator@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.1.2.tgz#24c5450db20f341f2b743ed4b07b907e18579216"
@@ -529,6 +661,13 @@
   integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-slot@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.0.tgz#57727fc186ddb40724ccfbe294e1a351d92462ba"
+  integrity sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
 
 "@radix-ui/react-tooltip@^1.1.8":
   version "1.1.8"
@@ -553,12 +692,24 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
   integrity sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==
 
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
 "@radix-ui/react-use-controllable-state@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz#1321446857bb786917df54c0d4d084877aab04b0"
   integrity sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==
   dependencies:
     "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-use-controllable-state@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.1.tgz#ec9c572072a6f269df7435c1652fbeebabe0f0c1"
+  integrity sha512-YnEXIy8/ga01Y1PN0VfaNH//MhA91JlEGVBDxDzROqwrAtG5Yr2QGEPz8A/rJA3C7ZAHryOYGaUv8fLSW2H/mg==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.1"
 
 "@radix-ui/react-use-escape-keydown@1.1.0":
   version "1.1.0"
@@ -567,10 +718,27 @@
   dependencies:
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
+"@radix-ui/react-use-escape-keydown@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
+  integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
 "@radix-ui/react-use-layout-effect@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
   integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
+"@radix-ui/react-use-previous@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz#1a1ad5568973d24051ed0af687766f6c7cb9b5b5"
+  integrity sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==
 
 "@radix-ui/react-use-rect@1.1.0":
   version "1.1.0"
@@ -579,12 +747,26 @@
   dependencies:
     "@radix-ui/rect" "1.1.0"
 
+"@radix-ui/react-use-rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz#01443ca8ed071d33023c1113e5173b5ed8769152"
+  integrity sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==
+  dependencies:
+    "@radix-ui/rect" "1.1.1"
+
 "@radix-ui/react-use-size@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz#b4dba7fbd3882ee09e8d2a44a3eed3a7e555246b"
   integrity sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
+
+"@radix-ui/react-use-size@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz#6de276ffbc389a537ffe4316f5b0f24129405b37"
+  integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
 
 "@radix-ui/react-visually-hidden@1.1.2":
   version "1.1.2"
@@ -593,10 +775,22 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.2"
 
+"@radix-ui/react-visually-hidden@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.3.tgz#f704c49121859941a8bb50ff1e4f156058cacd0b"
+  integrity sha512-oXSF3ZQRd5fvomd9hmUCb2EHSZbPp3ZSHAHJJU/DlF9XoFkJBBW8RHU/E8WEH+RbSfJd/QFA0sl8ClJXknBwHQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.3"
+
 "@radix-ui/rect@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
+
+"@radix-ui/rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
+  integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #43 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

폴리곤 받아와서 충돌 해결하고, 어노테이션 페이지 레이아웃 와이어 프레임 수준으로만 잡았습니다!
[ Annotation 헤더 관련 ]
1. Annotation History (Select) : 현재는 더미의 id값 + 날짜로 구성
2. Model Type (Select) : Cell / Tissue / Multi
3. Model Name (Input) : 현재는 ReadOnly, 추후 수정하는 다이얼로그 띄우는 방식으로 수정할 예정
4. Train / Run / Save (Button) : 각 학습 / 추론 / 저장 버튼, 추후 훅으로 관리

[ Annotation 사이드바 및 서브프로젝트 슬라이더 관련 ]
- 두 컴포넌트는 뷰어 컴포넌트 안에서 렌더링 됩니다. 최대한 분리해 보고 싶었으나, 뷰어 컴포넌트의 상태를 직접적으로 받기 때문에 뷰어 컴포넌트보다 상위에서 관리하면 상태관리를 전역적으로 하는 방식을 고려해야 합니다.
- 어노테이션 페이지를 전역적으로 관리했을 때 vs 컴포넌트 단에서 관리했을 때 두 가지 상황을 고려하면, 전역적으로 관리했을 때 불필요하게 무거워질 수 밖에 없다고 생각합니다. 따라서 우선 후자의 방식으로 구현했습니다! 

### 스크린샷 (선택)

<img width="1470" alt="스크린샷 2025-04-14 오후 9 03 15" src="https://github.com/user-attachments/assets/9bbff56d-efdc-4ae8-80cc-19e173a23ba2" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- [ Annotation 헤더 관련 ] 4번에 버튼 네이밍이 UX적으로 맞는지 고민입니다 😢
- OSD 뷰어는 정확한 픽셀값을 넣지 않으면 렌더링이 되지 않아서 반응형 커스텀이 필요할 것 같습니다! 현재는 제 맥북에서 예쁘게 보이는 대로 픽셀값 우선 넣어뒀습니다..
- 아마.. `frontend/develop` 에서 pull 받는 과정에서 뭔가 한 번 잘못 머지된 것 같은데요... (`frontend/develop` <- #43 ) 현재 PR에서 충돌 다 해결하여 올리는 것이니 염려하지 않으셔도 됩니다 ☮️ 💡 