### PR TITLE
[ BE ] feat/#52 학습 + 추론 결과 생성 api 구현

### DIFF
--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
@@ -2,6 +2,7 @@ package site.pathos.domain.annotation.tissueAnnotation.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import site.pathos.domain.annotation.tissueAnnotation.entity.AnnotationType;
 import site.pathos.domain.annotation.tissueAnnotation.entity.TissueAnnotation;
@@ -78,5 +79,16 @@ public class TissueAnnotationService {
         } catch (Exception e) {
             throw new RuntimeException("병합 이미지 업로드 실패", e);
         }
+    }
+
+    @Transactional
+    public void saveResultAnnotation(Roi roi, String imagePath) {
+        TissueAnnotation annotation = TissueAnnotation.builder()
+                .roi(roi)
+                .annotationImagePath(imagePath)
+                .annotationType(AnnotationType.RESULT)
+                .build();
+
+        tissueAnnotationRepository.save(annotation);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
@@ -1,0 +1,23 @@
+package site.pathos.domain.annotationHistory.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.pathos.domain.annotationHistory.service.AnnotationHistoryService;
+
+@RestController
+@RequestMapping("/api/annotation-histories")
+@RequiredArgsConstructor
+public class AnnotationHistoryController {
+
+    private final AnnotationHistoryService annotationHistoryService;
+
+    @PatchMapping("/{id}/model-name")
+    public ResponseEntity<Void> updateModelName(
+            @PathVariable("id") Long annotationHistoryId,
+            @RequestParam("name") String modelName
+    ) {
+        annotationHistoryService.updateModelName(annotationHistoryId, modelName);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -28,10 +28,20 @@ public class AnnotationHistory {
     @JoinColumn(name = "model_id", nullable = false)
     private Model model;
 
+    @Column(name = "model_name", nullable = false)
+    private String modelName;
+
     @CreationTimestamp
     @Column(name = "started_at", nullable = false)
     private LocalDateTime startedAt;
 
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
+
+    public void updateModelName(String newName) {
+        if (newName == null || newName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Model name must not be empty");
+        }
+        this.modelName = newName;
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
@@ -1,0 +1,22 @@
+package site.pathos.domain.annotationHistory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AnnotationHistoryService {
+
+    private final AnnotationHistoryRepository annotationHistoryRepository;
+
+    @Transactional
+    public void updateModelName(Long annotationHistoryId, String newModelName) {
+        AnnotationHistory history = annotationHistoryRepository.findById(annotationHistoryId)
+                .orElseThrow(() -> new IllegalArgumentException("AnnotationHistory not found"));
+
+        history.updateModelName(newModelName);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/InferenceHistory.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/InferenceHistory.java
@@ -2,9 +2,11 @@ package site.pathos.domain.inferenceHistory.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +22,7 @@ public class InferenceHistory {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "annotation_history_id", nullable = false)
-    private InferenceHistory inferenceHistory;
+    private AnnotationHistory annotationHistory;
 
     @Column(name = "accuracy")
     private Float accuracy;
@@ -29,7 +31,7 @@ public class InferenceHistory {
     private Float loss;
 
     @Column(name = "loop_performance")
-    private Float loop_performance;
+    private Float loopPerformance;
 
     @CreationTimestamp
     @Column(name = "created_at")
@@ -37,4 +39,16 @@ public class InferenceHistory {
 
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
+
+    @Builder
+    public InferenceHistory(AnnotationHistory annotationHistory){
+        this.annotationHistory = annotationHistory;
+    }
+
+    public void updateResult(float accuracy, float loss, float loopPerformance) {
+        this.accuracy = accuracy;
+        this.loss = loss;
+        this.loopPerformance = loopPerformance;
+        this.completedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/InferenceHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/InferenceHistoryRepository.java
@@ -1,0 +1,12 @@
+package site.pathos.domain.inferenceHistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.inferenceHistory.entity.InferenceHistory;
+
+import java.util.Optional;
+
+@Repository
+public interface InferenceHistoryRepository extends JpaRepository<InferenceHistory, Long> {
+    Optional<InferenceHistory> findByAnnotationHistoryId(Long annotationHistoryId);
+}

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/service/InferenceHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/service/InferenceHistoryService.java
@@ -1,0 +1,31 @@
+package site.pathos.domain.inferenceHistory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.inferenceHistory.entity.InferenceHistory;
+import site.pathos.domain.inferenceHistory.repository.InferenceHistoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class InferenceHistoryService {
+    private final InferenceHistoryRepository inferenceHistoryRepository;
+
+    @Transactional
+    public void saveInferenceHistory(AnnotationHistory annotationHistory){
+        InferenceHistory inferenceHistory = InferenceHistory.builder()
+                .annotationHistory(annotationHistory)
+                .build();
+
+        inferenceHistoryRepository.save(inferenceHistory);
+    }
+
+    @Transactional
+    public void updateInferenceHistory(Long annotationHistoryId, float accuracy, float loss, float loopPerformance) {
+        InferenceHistory history = inferenceHistoryRepository.findByAnnotationHistoryId(annotationHistoryId)
+                .orElseThrow(() -> new RuntimeException("InferenceHistory not found"));
+
+        history.updateResult(accuracy, loss, loopPerformance);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/model/Repository/ModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/Repository/ModelRepository.java
@@ -1,0 +1,9 @@
+package site.pathos.domain.model.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.model.entitiy.Model;
+
+@Repository
+public interface ModelRepository extends JpaRepository<Model, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
@@ -34,7 +34,4 @@ public class Model {
     @CreationTimestamp
     @Column(name = "trained_at", nullable = false)
     private LocalDateTime trainedAt;
-
-
-
 }

--- a/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entitiy/Model.java
@@ -2,6 +2,7 @@ package site.pathos.domain.model.entitiy;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -25,13 +26,17 @@ public class Model {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "model_version", nullable = false)
-    private String modelVersion;
-
     @Column(name = "model_path", nullable = false)
     private String modelPath;
 
     @CreationTimestamp
     @Column(name = "trained_at", nullable = false)
     private LocalDateTime trainedAt;
+
+    @Builder
+    public Model(AnnotationHistory annotationHistory, String name, String modelPath) {
+        this.annotationHistory = annotationHistory;
+        this.name = name;
+        this.modelPath = modelPath;
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
+++ b/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
@@ -1,0 +1,25 @@
+package site.pathos.domain.model.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.model.Repository.ModelRepository;
+import site.pathos.domain.model.entitiy.Model;
+
+@Service
+@RequiredArgsConstructor
+public class ModelService {
+    private final ModelRepository modelRepository;
+
+    @Transactional
+    public void saveModel(AnnotationHistory history, String modelName, String modelPath){
+        Model model = Model.builder()
+                .annotationHistory(history)
+                .name(modelName)
+                .modelPath(modelPath)
+                .build();
+
+        modelRepository.save(model);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
@@ -22,7 +22,7 @@ public class ModelServerController {
 
     @PostMapping("/training/result")
     public ResponseEntity<Void> responseTraining(@RequestBody TrainingResultRequestDto resultRequestDto){
-
+        modelServerService.resultTraining(resultRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
@@ -4,6 +4,7 @@ package site.pathos.domain.modelServer.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import site.pathos.domain.modelServer.dto.request.TrainingResultRequestDto;
 import site.pathos.domain.modelServer.service.ModelServerService;
 
 @RestController
@@ -14,8 +15,14 @@ public class ModelServerController {
     private final ModelServerService modelServerService;
 
     @PostMapping("/training")
-    public ResponseEntity<Void> requestInference(@RequestParam("annotation_history_id") Long annotationHistoryId) {
+    public ResponseEntity<Void> requestTraining(@RequestParam("annotation_history_id") Long annotationHistoryId) {
         modelServerService.requestTraining(annotationHistoryId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/training/result")
+    public ResponseEntity<Void> responseTraining(@RequestBody TrainingResultRequestDto resultRequestDto){
+
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestDto.java
@@ -6,6 +6,7 @@ public record TrainingRequestDto(
         Long sub_project_id,
         Long annotation_history_id,
         String type,
+        String model_name,
         String model_path,
         String svs_path,
         List<RoiPayload> roi

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 public record TrainingResultRequestDto(
         Long sub_project_id,
         Long annotation_history_id,
-        String model_name,
         String model_path,
         List<RoiPayload> roi
 ) { }

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
@@ -1,0 +1,11 @@
+package site.pathos.domain.modelServer.dto.request;
+
+import java.util.List;
+
+public record TrainingResultRequestDto(
+        Long sub_project_id,
+        Long annotation_history_id,
+        String model_name,
+        String model_path,
+        List<RoiPayload> roi
+) { }

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -78,7 +78,7 @@ public class ModelServerService {
                 .findWithSubProjectAndModelById(resultRequestDto.annotation_history_id())
                 .orElseThrow(() -> new RuntimeException("not found"));
 
-        modelService.saveModel(history, resultRequestDto.model_name(), resultRequestDto.model_path());
+        modelService.saveModel(history, history.getModelName(), resultRequestDto.model_path());
 
         //TODO 모델서버에서 기능 추가시 수정 필요
         inferenceHistoryService.updateInferenceHistory(resultRequestDto.annotation_history_id(),

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -19,6 +19,7 @@ import site.pathos.domain.roi.dto.request.RoiDetail;
 import site.pathos.domain.modelServer.dto.request.RoiPayload;
 import site.pathos.domain.roi.entity.Roi;
 import site.pathos.domain.modelServer.dto.request.TrainingRequestDto;
+import site.pathos.domain.roi.service.RoiService;
 import site.pathos.global.aws.sqs.service.SqsService;
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class ModelServerService {
     private final ModelService modelService;
     private final SqsService sqsService;
     private final InferenceHistoryService inferenceHistoryService;
+    private final RoiService roiService;
 
     @Transactional
     public void requestTraining(Long annotationHistoryId) {
@@ -76,7 +78,7 @@ public class ModelServerService {
                 .findWithSubProjectAndModelById(resultRequestDto.annotation_history_id())
                 .orElseThrow(() -> new RuntimeException("not found"));
 
-         modelService.saveModel(history, resultRequestDto.model_name(), resultRequestDto.model_path());
+        modelService.saveModel(history, resultRequestDto.model_name(), resultRequestDto.model_path());
 
         //TODO 모델서버에서 기능 추가시 수정 필요
         inferenceHistoryService.updateInferenceHistory(resultRequestDto.annotation_history_id(),
@@ -86,5 +88,6 @@ public class ModelServerService {
                 );
 
         //roi 새로 저장
+        roiService.saveResultRois(resultRequestDto.annotation_history_id(), resultRequestDto.roi());
     }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -55,6 +55,7 @@ public class ModelServerService {
                 history.getSubProject().getId(),
                 history.getId(),
                 ModelRequestType.TRAINING_INFERENCE.name(),
+                history.getModelName(),
                 history.getModel().getModelPath(),
                 history.getSubProject().getSvsImageUrl(),
                 roiMessages

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiDetail.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiDetail.java
@@ -1,3 +1,8 @@
 package site.pathos.domain.roi.dto.request;
 
-public record RoiDetail(int x, int y, int width, int height) {}
+public record RoiDetail(
+        int x,
+        int y,
+        int width,
+        int height
+) {}

--- a/backend/src/main/java/site/pathos/global/util/ImageUtils.java
+++ b/backend/src/main/java/site/pathos/global/util/ImageUtils.java
@@ -53,7 +53,6 @@ public class ImageUtils {
         else return 3 + (int) Math.ceil((dimension - 40000) / 10000.0);
     }
 
-    // 이미지 자르기 메서드
     public static List<BufferedImage> sliceImageByROI(BufferedImage image, int roiX, int roiY, int roiWidth, int roiHeight) {
         List<BufferedImage> tiles = new ArrayList<>();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #52 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- /api/model-server/traing/result [post]를 통해 모델서버에서 완료한 결과물을 전송하도록 Api를 구현하였습니다.
- 각 annotation history에도 model_name을 추가하여 중간 과정에 저장하거나 모델 생성시 해당 필드를 활용합니다.

요청 형식

```
{
  "sub_project_id": 1,
  "annotation_history_id": 4,
  "model_name": "tumor-classifier-v1",
  "model_path": "sub-project/1/model/0.pth",
  "roi": [
    {
      "detail": {
        "x": 0,
        "y": 0,
        "width": 31428,
        "height": 27978
      },
      "tissue_path": "sub-project/1/annotation-history/4/roi-1/result.png",
      "cell": [
        {
          "x": 100,
          "y": 200
        },
        {
          "x": 150,
          "y": 300
        }
      ]
    }
  ]
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
