### PR TITLE
[ BE ] feat/#72 subproject detail 불러오는 api 구현

### DIFF
--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record AnnotationHistorySummaryDto(
         Long id,
+        int order,
         LocalDateTime startedAt,
         LocalDateTime completedAt
 ) {

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
@@ -1,0 +1,10 @@
+package site.pathos.domain.annotationHistory.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AnnotationHistorySummaryDto(
+        Long id,
+        LocalDateTime startedAt,
+        LocalDateTime completedAt
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -26,7 +26,7 @@ public class AnnotationHistory {
     private SubProject subProject;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "model_id", nullable = false)
+    @JoinColumn(name = "model_id")
     private Model model;
 
     @Column(name = "model_name", nullable = false)

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import site.pathos.domain.model.entity.Model;
-import site.pathos.domain.subProject.SubProject;
+import site.pathos.domain.subProject.entity.SubProject;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,6 @@ public interface AnnotationHistoryRepository extends JpaRepository<AnnotationHis
         WHERE ah.id = :id
     """)
     Optional<AnnotationHistory> findWithSubProjectAndModelById(@Param("id") Long id);
+
+    List<AnnotationHistory> findAllBySubProjectId(Long subProjectId);
 }

--- a/backend/src/main/java/site/pathos/domain/model/ModelSummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/model/ModelSummaryDto.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.model;
+
+public record ModelSummaryDto(
+        Long id,
+        String name
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/model/entity/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/Model.java
@@ -37,9 +37,10 @@ public class Model {
     private LocalDateTime trainedAt;
 
     @Builder
-    public Model(AnnotationHistory annotationHistory, String name, String modelPath) {
+    public Model(AnnotationHistory annotationHistory, String name, ModelType modelType, String modelPath) {
         this.annotationHistory = annotationHistory;
         this.name = name;
+        this.modelType = modelType;
         this.modelPath = modelPath;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/model/entity/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/Model.java
@@ -26,6 +26,9 @@ public class Model {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "model_type", nullable = false)
+    private ModelType modelType;
+
     @Column(name = "model_path", nullable = false)
     private String modelPath;
 

--- a/backend/src/main/java/site/pathos/domain/model/entity/ModelType.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/ModelType.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.model.entity;
+
+public enum ModelType {
+    TISSUE,
+    CELL,
+    MULTI
+}

--- a/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
+++ b/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.model.Repository.ModelRepository;
 import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.model.entity.ModelType;
 
 @Service
 @RequiredArgsConstructor
@@ -13,10 +14,11 @@ public class ModelService {
     private final ModelRepository modelRepository;
 
     @Transactional
-    public void saveModel(AnnotationHistory history, String modelName, String modelPath){
+    public void saveModel(AnnotationHistory history, String modelName, ModelType modelType, String modelPath){
         Model model = Model.builder()
                 .annotationHistory(history)
                 .name(modelName)
+                .modelType(modelType)
                 .modelPath(modelPath)
                 .build();
 

--- a/backend/src/main/java/site/pathos/domain/project/entity/Project.java
+++ b/backend/src/main/java/site/pathos/domain/project/entity/Project.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import site.pathos.domain.model.entity.ModelType;
 import site.pathos.domain.user.entity.User;
 
 import java.time.LocalDate;
@@ -31,6 +32,9 @@ public class Project {
 
     @Column(name = "thumbnail_image_url", nullable = false)
     private String thumbnailImageUrl;
+
+    @Column(name = "model_type" , nullable = false)
+    private ModelType modelType;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)

--- a/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
+++ b/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
@@ -69,18 +69,7 @@ public class RoiService {
     }
 
     @Transactional
-    public void saveResultRois(Long annotationHistoryId, List<RoiPayload> roiPayloads) {
-        AnnotationHistory history = annotationHistoryRepository.findById(annotationHistoryId)
-                .orElseThrow(() -> new IllegalArgumentException("AnnotationHistory not found"));
-
-        AnnotationHistory newHistory = AnnotationHistory.builder()
-                .subProject(history.getSubProject())
-                .model(history.getModel())
-                .modelName(history.getModelName())
-                .build();
-
-        annotationHistoryRepository.save(newHistory);
-
+    public void saveResultRois(AnnotationHistory newHistory, List<RoiPayload> roiPayloads) {
         for (RoiPayload payload : roiPayloads) {
             Roi roi = Roi.builder()
                     .annotationHistory(newHistory)

--- a/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
@@ -1,0 +1,27 @@
+package site.pathos.domain.subProject.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.pathos.domain.subProject.dto.response.SubProjectResponseDto;
+import site.pathos.domain.subProject.service.SubProjectService;
+
+@RestController
+@RequestMapping("/api/subprojects")
+@RequiredArgsConstructor
+public class SubProjectController {
+
+    private final SubProjectService subProjectService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SubProjectResponseDto> getSubProject(
+            @PathVariable("id") Long subProjectId
+    ){
+        SubProjectResponseDto response = subProjectService.getSubProject(subProjectId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
@@ -1,0 +1,15 @@
+package site.pathos.domain.subProject.dto.response;
+
+import site.pathos.domain.annotationHistory.dto.response.AnnotationHistorySummaryDto;
+import site.pathos.domain.model.ModelSummaryDto;
+import site.pathos.domain.model.entity.ModelType;
+
+import java.util.List;
+
+public record SubProjectResponseDto(
+        Long subProjectId,
+        List<AnnotationHistorySummaryDto> annotationHistories,
+        List<ModelSummaryDto> availableModels,
+        ModelType modelType
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -1,4 +1,4 @@
-package site.pathos.domain.subProject;
+package site.pathos.domain.subProject.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
@@ -1,0 +1,12 @@
+package site.pathos.domain.subProject.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.subProject.entity.SubProject;
+
+public interface SubProjectRepository extends JpaRepository<SubProject, Long> {
+    @Query("SELECT s.project FROM SubProject s WHERE s.id = :subProjectId")
+    Project findProjectBySubProjectId(@Param("subProjectId") Long subProjectId);
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
@@ -12,7 +12,9 @@ import site.pathos.domain.subProject.dto.response.SubProjectResponseDto;
 import site.pathos.domain.subProject.repository.SubProjectRepository;
 import site.pathos.domain.userModel.repository.UserModelRepository;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -23,13 +25,22 @@ public class SubProjectService {
     private final SubProjectRepository subProjectRepository;
 
     public SubProjectResponseDto getSubProject(Long subProjectId){
-        List<AnnotationHistory> histories = annotationHistoryRepository.findAllBySubProjectId(subProjectId);
-        List<AnnotationHistorySummaryDto> historyDtos = histories.stream()
-                .map(h -> new AnnotationHistorySummaryDto(
-                        h.getId(),
-                        h.getStartedAt(),
-                        h.getCompletedAt() // 필요시 포맷 적용
-                ))
+        List<AnnotationHistory> histories = annotationHistoryRepository
+                .findAllBySubProjectId(subProjectId)
+                .stream()
+                .sorted(Comparator.comparing(AnnotationHistory::getStartedAt)) // startedAt 기준 정렬
+                .toList();
+
+        List<AnnotationHistorySummaryDto> historyDtos = IntStream.range(0, histories.size())
+                .mapToObj(i -> {
+                    AnnotationHistory h = histories.get(i);
+                    return new AnnotationHistorySummaryDto(
+                            h.getId(),
+                            i+1,
+                            h.getStartedAt(),
+                            h.getCompletedAt()// 1번부터 시작
+                    );
+                })
                 .toList();
 
         //TODO 나중에 실제 userId로 변경 필요

--- a/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
@@ -1,0 +1,55 @@
+package site.pathos.domain.subProject.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.pathos.domain.annotationHistory.dto.response.AnnotationHistorySummaryDto;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
+import site.pathos.domain.model.ModelSummaryDto;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.subProject.dto.response.SubProjectResponseDto;
+import site.pathos.domain.subProject.repository.SubProjectRepository;
+import site.pathos.domain.userModel.repository.UserModelRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SubProjectService {
+
+    private final AnnotationHistoryRepository annotationHistoryRepository;
+    private final UserModelRepository userModelRepository;
+    private final SubProjectRepository subProjectRepository;
+
+    public SubProjectResponseDto getSubProject(Long subProjectId){
+        List<AnnotationHistory> histories = annotationHistoryRepository.findAllBySubProjectId(subProjectId);
+        List<AnnotationHistorySummaryDto> historyDtos = histories.stream()
+                .map(h -> new AnnotationHistorySummaryDto(
+                        h.getId(),
+                        h.getStartedAt(),
+                        h.getCompletedAt() // 필요시 포맷 적용
+                ))
+                .toList();
+
+        //TODO 나중에 실제 userId로 변경 필요
+        Long userId =  1L;
+
+        List<Model> models = userModelRepository.findAllModelsByUserId(userId); // 조건에 따라 필터링 가능
+        List<ModelSummaryDto> modelDtos = models.stream()
+                .map(m -> new ModelSummaryDto(
+                        m.getId(),
+                        m.getName()
+                ))
+                .toList();
+
+        Project project = subProjectRepository.findProjectBySubProjectId(subProjectId);
+
+        return new SubProjectResponseDto(
+                subProjectId,
+                historyDtos,
+                modelDtos,
+                project.getModelType()
+        );
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/userModel/repository/UserModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/userModel/repository/UserModelRepository.java
@@ -1,0 +1,16 @@
+package site.pathos.domain.userModel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.userModel.entity.UserModel;
+
+import java.util.List;
+
+@Repository
+public interface UserModelRepository extends JpaRepository<UserModel, Long> {
+    @Query("SELECT m FROM UserModel u JOIN u.model m WHERE u.id = :userId")
+    List<Model> findAllModelsByUserId(@Param("userId") Long userId);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #72 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Subproject의 Id를 통해 아래 정보들을 불러오는 API를 구현했습니다.
1. 서브프로젝트에 해당하는 history 목록
2. 선택 가능한 모델 목록
3. 모델 타입

- 추후 인증 정보를 통해 실제 userId로 불러오는 로직을 구현해야합니다.
- 응답 양식
```
{
  "subProjectId": 1,
  "annotationHistories": [
    {
      "id": 1,
      "order": 1,
      "startedAt": "2025-04-21T06:03:22",
      "completedAt": null
    }
  ],
  "availableModels": [
    {
      "id": 1,
      "name": "TestModel"
    }
  ],
  "modelType": "TISSUE"
}
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
