### PR TITLE
[ BE ] feat/#74 project info 불러오는 로직 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,4 +66,4 @@ jobs:
         run: sudo docker run --name pathos --rm -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/pathos:latest
 
       - name: delete old docker image
-        run: sudo docker image prune -
+        run: sudo docker image prune -f

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
@@ -13,19 +13,19 @@ public class AnnotationHistoryController {
 
     private final AnnotationHistoryService annotationHistoryService;
 
-    @PatchMapping("/{id}/model-name")
+    @PatchMapping("/{annotationHistoryId}/model-name")
     public ResponseEntity<Void> updateModelName(
-            @PathVariable("id") Long annotationHistoryId,
+            @PathVariable("annotationHistoryId") Long annotationHistoryId,
             @RequestParam("name") String modelName
     ) {
         annotationHistoryService.updateModelName(annotationHistoryId, modelName);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{annotationHistoryId}")
     public ResponseEntity<AnnotationHistoryResponseDto> getAnnotationHistory(
-            @PathVariable("id") Long historyId) {
-        AnnotationHistoryResponseDto response = annotationHistoryService.getAnnotationHistory(historyId);
+            @PathVariable("annotationHistoryId") Long annotationHistoryId) {
+        AnnotationHistoryResponseDto response = annotationHistoryService.getAnnotationHistory(annotationHistoryId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
@@ -1,0 +1,23 @@
+package site.pathos.domain.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.pathos.domain.project.dto.response.ProjectDetailDto;
+import site.pathos.domain.project.service.ProjectService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectDetailDto> getProjectDetail(
+            @PathVariable Long projectId
+    ) {
+        ProjectDetailDto response = projectService.getProjectDetail(projectId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/project/dto/response/ProjectDetailDto.java
+++ b/backend/src/main/java/site/pathos/domain/project/dto/response/ProjectDetailDto.java
@@ -1,0 +1,12 @@
+package site.pathos.domain.project.dto.response;
+
+import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
+
+import java.util.List;
+
+public record ProjectDetailDto(
+        Long projectId,
+        String title,
+        List<SubProjectSummaryDto> subProjects
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.pathos.domain.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -1,0 +1,33 @@
+package site.pathos.domain.project.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import site.pathos.domain.project.dto.response.ProjectDetailDto;
+import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.project.repository.ProjectRepository;
+import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
+import site.pathos.domain.subProject.repository.SubProjectRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+    private final SubProjectRepository subProjectRepository;
+
+    public ProjectDetailDto getProjectDetail(Long projectId){
+        List<SubProjectSummaryDto> subProjects = subProjectRepository.findSubProjectIdAndThumbnailByProjectId(projectId);
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project not found: id = " + projectId));
+
+        return new ProjectDetailDto(
+                projectId,
+                project.getTitle(),
+                subProjects
+        );
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
@@ -17,9 +17,9 @@ public class SubProjectController {
 
     private final SubProjectService subProjectService;
 
-    @GetMapping("/{id}")
+    @GetMapping("/{subProjectId}")
     public ResponseEntity<SubProjectResponseDto> getSubProject(
-            @PathVariable("id") Long subProjectId
+            @PathVariable("subProjectId") Long subProjectId
     ){
         SubProjectResponseDto response = subProjectService.getSubProject(subProjectId);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
@@ -9,6 +9,7 @@ import java.util.List;
 public record SubProjectResponseDto(
         Long subProjectId,
         List<AnnotationHistorySummaryDto> annotationHistories,
+        Long latestAnnotationHistoryId,
         List<ModelSummaryDto> availableModels,
         ModelType modelType
 ) {

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectSummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectSummaryDto.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.subProject.dto.response;
+
+public record SubProjectSummaryDto(
+        Long subProjectId,
+        String thumbnailUrl
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -22,4 +22,7 @@ public class SubProject {
 
     @Column(name = "svs_image_url")
     private String svsImageUrl;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
@@ -4,9 +4,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
 import site.pathos.domain.subProject.entity.SubProject;
+
+import java.util.List;
 
 public interface SubProjectRepository extends JpaRepository<SubProject, Long> {
     @Query("SELECT s.project FROM SubProject s WHERE s.id = :subProjectId")
     Project findProjectBySubProjectId(@Param("subProjectId") Long subProjectId);
+
+    @Query("SELECT new site.pathos.domain.subProject.dto.response.SubProjectSummaryDto(sp.id, sp.thumbnailUrl) " +
+            "FROM SubProject sp WHERE sp.project.id = :projectId")
+    List<SubProjectSummaryDto> findSubProjectIdAndThumbnailByProjectId(@Param("projectId") Long projectId);
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
@@ -25,6 +25,7 @@ public class SubProjectService {
     private final SubProjectRepository subProjectRepository;
 
     public SubProjectResponseDto getSubProject(Long subProjectId){
+        //TODO 추후에 메서드 분리 필요
         List<AnnotationHistory> histories = annotationHistoryRepository
                 .findAllBySubProjectId(subProjectId)
                 .stream()
@@ -43,6 +44,11 @@ public class SubProjectService {
                 })
                 .toList();
 
+        Long latestAnnotationHistoryId = histories.isEmpty()
+                ? null
+                : histories.get(histories.size() - 1).getId();
+
+
         //TODO 나중에 실제 userId로 변경 필요
         Long userId =  1L;
 
@@ -59,6 +65,7 @@ public class SubProjectService {
         return new SubProjectResponseDto(
                 subProjectId,
                 historyDtos,
+                latestAnnotationHistoryId,
                 modelDtos,
                 project.getModelType()
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #74 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [GET] /api/project/{projectId} 구현
```
{
  "projectId": 0,
  "title": "string",
  "subProjects": [
    {
      "subProjectId": 0,
      "thumbnailUrl": "string"
    }
  ]
}
```
- [GET] /api/subProject/{subProjectId} 에 latestHistoryId 추가
```
{
  "subProjectId": 0,
  "annotationHistories": [
    {
      "id": 0,
      "order": 0,
      "startedAt": "2025-04-25T07:13:46.852Z",
      "completedAt": "2025-04-25T07:13:46.852Z"
    }
  ],
  "latestAnnotationHistoryId": 0,
  "availableModels": [
    {
      "id": 0,
      "name": "string"
    }
  ],
  "modelType": "TISSUE"
}
```
@gyuwonsong  project진입 시 (/api/project/{projectId})로 subProject들의 id를 읽어오고 가장 첫번째 subProjectId로  (/api/subProject/{subProjectId})에 요청을 하여 detail 정보를 받아오시면 될 것 같습니다.

- path 변수명 리펙토링
<img width="1448" alt="image" src="https://github.com/user-attachments/assets/b9741416-26de-4b0a-8648-6f6da2a29abd" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
