### PR TITLE
[ BE ] feat/#84 썸네일 및 타일 이미지 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3-transfer-manager:2.25.64'
 	implementation 'software.amazon.awssdk:auth-crt:2.25.64'
 	implementation 'software.amazon.awssdk:sqs:2.25.64'
+	implementation 'software.amazon.awssdk:ec2:2.25.64'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -86,6 +86,8 @@ public class ProjectService {
                     .build();
             subProjectRepository.save(subProject);
             String svsKey = subProject.initializeSvsImageUrl();
+            subProject.initializeThumbnailImageUrl();
+            subProject.initializeTileImageUrl();
             uploadFiles.add(new S3UploadFileDto(subProject.getId(), svsKey, file));
 
             AnnotationHistory annotationHistory = AnnotationHistory.builder()

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -23,12 +23,14 @@ import site.pathos.domain.project.dto.response.ProjectDetailDto;
 import site.pathos.domain.project.entity.Project;
 import site.pathos.domain.project.enums.ProjectSortType;
 import site.pathos.domain.project.repository.ProjectRepository;
+import site.pathos.domain.subProject.dto.request.SubProjectTilingRequestDto;
 import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
 import site.pathos.domain.subProject.entity.SubProject;
 import site.pathos.domain.subProject.repository.SubProjectRepository;
 import site.pathos.domain.user.entity.User;
 import site.pathos.domain.user.repository.UserRepository;
 import site.pathos.domain.userModel.repository.UserModelRepository;
+import site.pathos.global.aws.ec2.Ec2Service;
 import site.pathos.global.aws.s3.S3Service;
 import site.pathos.global.aws.s3.dto.S3UploadFileDto;
 import site.pathos.global.common.PaginationResponse;
@@ -45,6 +47,8 @@ public class ProjectService {
     private final ModelRepository modelRepository;
     private final UserModelRepository userModelRepository;
     private static final int PROJECTS_PAGE_SIZE = 9;
+
+    private final Ec2Service ec2Service;
 
     public ProjectDetailDto getProjectDetail(Long projectId){
         List<SubProjectSummaryDto> subProjects = subProjectRepository.findSubProjectIdAndThumbnailByProjectId(projectId);
@@ -81,7 +85,7 @@ public class ProjectService {
                     .build();
             subProjectRepository.save(subProject);
             String svsKey = subProject.initializeSvsImageUrl();
-            uploadFiles.add(new S3UploadFileDto(svsKey, file));
+            uploadFiles.add(new S3UploadFileDto(subProject.getId(), svsKey, file));
 
             AnnotationHistory annotationHistory = AnnotationHistory.builder()
                     .subProject(subProject)
@@ -90,7 +94,12 @@ public class ProjectService {
                     .build();
             annotationHistoryRepository.save(annotationHistory);
         }
-        s3Service.uploadFilesAsync(uploadFiles);
+
+        s3Service.uploadFilesAsync(uploadFiles, uploadImages -> {
+            for (SubProjectTilingRequestDto image : uploadImages) {
+                ec2Service.asyncLaunchTilingInstance(image);
+            }
+        });
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/request/SubProjectTilingRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/request/SubProjectTilingRequestDto.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.subProject.dto.request;
+
+public record SubProjectTilingRequestDto(
+        Long subProjectId,
+        String s3Path
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -39,6 +39,9 @@ public class SubProject {
     @Column(name = "svs_image_url")
     private String svsImageUrl;
 
+    @Column(name = "tile_image_url")
+    private String tileImageUrl;
+
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
@@ -52,5 +55,19 @@ public class SubProject {
             throw new IllegalStateException("SubProject ID must be set before initializing svsImageUrl.");
         }
         return this.svsImageUrl = String.format("sub-project/%s/svs/original.svs", this.id);
+    }
+
+    public String initializeThumbnailImageUrl() {
+        if (this.id == null) {
+            throw new IllegalStateException("SubProject ID must be set before initializing thumbnailImageUrl.");
+        }
+        return this.thumbnailUrl = String.format("sub-project/%s/thumbnail/thumbnail.jpg", this.id);
+    }
+
+    public String initializeTileImageUrl() {
+        if (this.id == null) {
+            throw new IllegalStateException("SubProject ID must be set before initializing tileImageUrl.");
+        }
+        return this.tileImageUrl = String.format("sub-project/%s/tiles/output_slide.dzi", this.id);
     }
 }

--- a/backend/src/main/java/site/pathos/global/aws/config/AwsClientConfig.java
+++ b/backend/src/main/java/site/pathos/global/aws/config/AwsClientConfig.java
@@ -1,0 +1,26 @@
+package site.pathos.global.aws.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+
+@Configuration
+public class AwsClientConfig {
+
+    private final AwsProperty awsProperty;
+    private final StaticCredentialsProvider awsCredentialsProvider;
+
+    public AwsClientConfig(AwsProperty awsProperty, StaticCredentialsProvider awsCredentialsProvider) {
+        this.awsProperty = awsProperty;
+        this.awsCredentialsProvider = awsCredentialsProvider;
+    }
+
+    @Bean
+    public Ec2Client ec2Client() {
+        return Ec2Client.builder()
+                .region(awsProperty.regionAsEnum())
+                .credentialsProvider(awsCredentialsProvider)
+                .build();
+    }
+}

--- a/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
+++ b/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
@@ -81,13 +81,17 @@ public class Ec2Service {
             --overlap=1 \\
             --suffix .jpg[Q=85] \\
             --depth onepixel
+        
+        vips thumbnail original.svs thumbnail.jpg 600
 
         aws s3 cp output_slide.dzi s3://%s/sub-project/%d/tiles/output_slide.dzi
         aws s3 cp output_slide_files/ s3://%s/sub-project/%d/tiles/output_slide_files/ --recursive
-
+        aws s3 cp thumbnail.jpg s3://%s/sub-project/%d/thumbnail/thumbnail.jpg
+                
         shutdown -h now
         """.formatted(
                 s3Path,
+                bucket, subProjectId,
                 bucket, subProjectId,
                 bucket, subProjectId
         );

--- a/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
+++ b/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
@@ -1,8 +1,6 @@
 package site.pathos.global.aws.ec2;
 
-import io.netty.handler.codec.base64.Base64Encoder;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -87,7 +85,7 @@ public class Ec2Service {
         aws s3 cp output_slide.dzi s3://%s/sub-project/%d/tiles/output_slide.dzi
         aws s3 cp output_slide_files/ s3://%s/sub-project/%d/tiles/output_slide_files/ --recursive
         aws s3 cp thumbnail.jpg s3://%s/sub-project/%d/thumbnail/thumbnail.jpg
-                
+        
         shutdown -h now
         """.formatted(
                 s3Path,

--- a/backend/src/main/java/site/pathos/global/aws/s3/dto/S3UploadFileDto.java
+++ b/backend/src/main/java/site/pathos/global/aws/s3/dto/S3UploadFileDto.java
@@ -3,6 +3,7 @@ package site.pathos.global.aws.s3.dto;
 import org.springframework.web.multipart.MultipartFile;
 
 public record S3UploadFileDto(
+        Long subProjectId,
         String key,
         MultipartFile file
 ) {

--- a/backend/src/main/java/site/pathos/global/config/AsyncConfig.java
+++ b/backend/src/main/java/site/pathos/global/config/AsyncConfig.java
@@ -1,9 +1,23 @@
 package site.pathos.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
+    @Bean(name = "tileExecutor")
+    public Executor tileExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("tile-ec2-");
+        executor.initialize();
+        return executor;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호 

- Closes #84 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

C6I_Xlarge 인스턴스를 스팟으로 활용하여 타일링 이미지 및 썸네일을 생성 및 저장하였습니다

- 타일링 dzi 파일 및 tile Image 저장
`{버킷 경로}/sub-project/{subProjectId}/tiles/*`
- 썸네일 이미지 저장
`{버킷 경로}/sub-project/{subProjectId}/thumbnail`

프론트에서는 아래와 같은 형식으로 dzi 파일을 불러와주시면 됩니다.
@hyeonjin6530 

```
iewer.addTiledImage({
                tileSource: 'https://pathos-images.s3.ap-northeast-2.amazonaws.com/tiles/slide123.dzi',
                success: {
                    "AnnotationTestViewer.useEffect": ()=>{
                        console.log('DZI image loaded successfully');
                    }
                }["AnnotationTestViewer.useEffect"]
            });
```


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
