### PR TITLE
[ BE ] feat/#112 ROI 및 이미지 저장 로직 수정

### DIFF
--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -27,6 +27,9 @@ public class TissueAnnotation {
     @Column(name = "annotation_type", nullable = false)
     private AnnotationType annotationType;
 
+    @Column(name = "is_upload_complete", nullable = false)
+    private boolean isUploadComplete;
+
     @Builder
     public TissueAnnotation(Roi roi, String annotationImageUrl, AnnotationType annotationType) {
         if (roi == null) throw new IllegalArgumentException("roi cannot be null in TissueAnnotation");
@@ -35,5 +38,10 @@ public class TissueAnnotation {
         this.roi = roi;
         this.annotationImageUrl = annotationImageUrl;
         this.annotationType = annotationType;
+        this.isUploadComplete = false;
+    }
+
+    public void uploadComplete() {
+        this.isUploadComplete = true;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -21,19 +21,19 @@ public class TissueAnnotation {
     private Roi roi;
 
     @Column(name = "annotation_image_url", nullable = false)
-    private String annotationImagePath;
+    private String annotationImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "annotation_type", nullable = false)
     private AnnotationType annotationType;
 
     @Builder
-    public TissueAnnotation(Roi roi, String annotationImagePath, AnnotationType annotationType) {
+    public TissueAnnotation(Roi roi, String annotationImageUrl, AnnotationType annotationType) {
         if (roi == null) throw new IllegalArgumentException("roi cannot be null in TissueAnnotation");
         if (annotationType == null) throw new IllegalArgumentException("annotationType is required");
 
         this.roi = roi;
-        this.annotationImagePath = annotationImagePath;
+        this.annotationImageUrl = annotationImageUrl;
         this.annotationType = annotationType;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/service/TissueAnnotationService.java
@@ -43,7 +43,7 @@ public class TissueAnnotationService {
 
             TissueAnnotation ta = TissueAnnotation.builder()
                     .roi(roi)
-                    .annotationImagePath(key)
+                    .annotationImageUrl(key)
                     .annotationType(AnnotationType.TILE)
                     .build();
 
@@ -53,25 +53,20 @@ public class TissueAnnotationService {
 
     private void uploadMergedImage(Long subProjectId, Long annotationHistoryId, Roi roi, List<MultipartFile> images) {
         try {
-            // 1. 병합 대상 이미지 크기 (ROI 기준)
             int totalWidth = roi.getWidth();
             int totalHeight = roi.getHeight();
 
-            // 2. 이미지 병합
             BufferedImage merged = ImageUtils.mergeTiles(images, totalWidth, totalHeight);
 
-            // 3. 업로드할 S3 경로
             String mergedKey = "sub-project/" + subProjectId
                     + "/annotation-history/" + annotationHistoryId
                     + "/roi-" + roi.getId() + "/merged.png";
 
-            // 4. S3에 업로드
             s3Service.uploadBufferedImage(merged, mergedKey);
 
-            // 5. DB에 TissueAnnotation 저장
             TissueAnnotation mergedAnnotation = TissueAnnotation.builder()
                     .roi(roi)
-                    .annotationImagePath(mergedKey)
+                    .annotationImageUrl(mergedKey)
                     .annotationType(AnnotationType.MERGED)
                     .build();
 
@@ -104,7 +99,7 @@ public class TissueAnnotationService {
 
             TissueAnnotation tileAnnotation = TissueAnnotation.builder()
                     .roi(roi)
-                    .annotationImagePath(tileKey)
+                    .annotationImageUrl(tileKey)
                     .annotationType(AnnotationType.RESULT_TILE)
                     .build();
 

--- a/backend/src/main/java/site/pathos/domain/label/entity/Label.java
+++ b/backend/src/main/java/site/pathos/domain/label/entity/Label.java
@@ -2,6 +2,7 @@ package site.pathos.domain.label.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
@@ -25,6 +26,21 @@ public class Label {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private AnnotationHistory annotationHistory;
+
+    @Builder
+    public Label(String name, String color, AnnotationHistory annotationHistory) {
+        this.name = name;
+        this.color = color;
+        this.annotationHistory = annotationHistory;
+    }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeColor(String color) {
+        this.color = color;
+    }
 
     public LabelDto toLabelDto() {
         return new LabelDto(

--- a/backend/src/main/java/site/pathos/domain/label/service/LabelService.java
+++ b/backend/src/main/java/site/pathos/domain/label/service/LabelService.java
@@ -1,0 +1,40 @@
+package site.pathos.domain.label.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.label.dto.LabelDto;
+import site.pathos.domain.label.entity.Label;
+import site.pathos.domain.label.repository.LabelRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LabelService {
+
+    private final LabelRepository labelRepository;
+
+    @Transactional
+    public void upsertLabels(List<LabelDto> labelDtos, AnnotationHistory history) {
+        for (LabelDto dto : labelDtos) {
+            if (dto.id() == null) {
+                // 신규 생성
+                Label newLabel = Label.builder()
+                        .name(dto.name())
+                        .color(dto.color())
+                        .annotationHistory(history)
+                        .build();
+                labelRepository.save(newLabel);
+            } else {
+                // 기존 항목 수정
+                Label existingLabel = labelRepository.findById(dto.id())
+                        .orElseThrow(() -> new IllegalArgumentException("Label not found: " + dto.id()));
+
+                existingLabel.changeName(dto.name());
+                existingLabel.changeColor(dto.color());
+            }
+        }
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -60,9 +60,9 @@ public class ModelServerService {
             // TODO: cell 관련 로직 추가 필요
             List<CellDetail> cellAnnotations = List.of();
 
-            List<String> imagePaths = List.of(ta.getAnnotationImagePath());
+            List<String> imagePaths = List.of(ta.getAnnotationImageUrl());
 
-            return new RoiRequestPayload(detail, imagePaths, cellAnnotations);
+            return new RoiRequestPayload(roi.getDisplayOrder(), detail, imagePaths, cellAnnotations);
         }).toList();
 
         return new TrainingRequestDto(

--- a/backend/src/main/java/site/pathos/domain/project/entity/Project.java
+++ b/backend/src/main/java/site/pathos/domain/project/entity/Project.java
@@ -68,6 +68,7 @@ public class Project {
         this.title = title;
         this.description = description;
         this.modelType = modelType;
+        isDeleted = false;
         setUpdatedAt();
     }
 

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -98,7 +98,7 @@ public class ProjectService {
             annotationHistoryRepository.save(annotationHistory);
         }
 
-        s3Service.uploadFilesAsync(uploadFiles, uploadImages -> {
+        s3Service.uploadSvsFilesAsync(uploadFiles, uploadImages -> {
             for (SubProjectTilingRequestDto image : uploadImages) {
                 ec2Service.asyncLaunchTilingInstance(image);
             }

--- a/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
+++ b/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import site.pathos.domain.label.dto.LabelDto;
 import site.pathos.domain.roi.dto.request.RoiSaveRequestDto;
 import site.pathos.domain.roi.service.RoiService;
 
@@ -24,9 +25,10 @@ public class RoiController {
             @RequestPart("subProjectId") Long subProjectId,
             @RequestPart("annotationHistoryId") Long annotationHistoryId,
             @RequestPart("rois") List<RoiSaveRequestDto> rois,
-            @RequestPart("images") List<MultipartFile> images
+            @RequestPart("images") List<MultipartFile> images,
+            @RequestPart("labels") List<LabelDto> labels
     ){
-        roiService.saveWithAnnotations(subProjectId, annotationHistoryId, rois, images);
+        roiService.saveWithAnnotations(subProjectId, annotationHistoryId, rois, images, labels);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
@@ -5,6 +5,7 @@ import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
 import java.util.List;
 
 public record RoiRequestPayload(
+        int displayOrder,
         RoiRequestDto detail,
         List<String> tissue_path,
         List<CellDetail> cell

--- a/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponsePayload.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponsePayload.java
@@ -5,6 +5,7 @@ import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
 import java.util.List;
 
 public record RoiResponsePayload(
+        int displayOrder,
         RoiResponseDto detail,
         List<String> tissue_path,
         List<CellDetail> cell

--- a/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
+++ b/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
@@ -43,8 +43,11 @@ public class Roi {
     @Column(name = "faulty")
     private Double faulty;
 
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
     @Builder
-    public Roi(AnnotationHistory annotationHistory, int x, int y, int width, int height) {
+    public Roi(AnnotationHistory annotationHistory, int x, int y, int width, int height, int displayOrder) {
         if (annotationHistory == null) throw new IllegalArgumentException("annotationHistory cannot be null");
 
         this.annotationHistory = annotationHistory;
@@ -52,6 +55,7 @@ public class Roi {
         this.y = y;
         this.width = width;
         this.height = height;
+        this.displayOrder = displayOrder;
     }
 
     public void changeCoordinates(int x, int y, int width, int height) {

--- a/backend/src/main/java/site/pathos/domain/roi/repository/RoiRepository.java
+++ b/backend/src/main/java/site/pathos/domain/roi/repository/RoiRepository.java
@@ -13,6 +13,14 @@ public interface RoiRepository extends JpaRepository<Roi, Long>{
     @Query("""
     SELECT r
     FROM Roi r
-    WHERE r.annotationHistory.id = :historyId""")
+    WHERE r.annotationHistory.id = :historyId
+    """)
     List<Roi> findAllByAnnotationHistoryId(@Param("historyId") Long historyId);
+
+    @Query("""
+    SELECT MAX(r.displayOrder)
+    FROM Roi r 
+    WHERE r.annotationHistory.id = :historyId
+    """)
+    Integer findMaxDisplayOrderByAnnotationHistory(@Param("historyId") Long historyId);
 }

--- a/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
+++ b/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
@@ -7,6 +7,8 @@ import org.springframework.web.multipart.MultipartFile;
 import site.pathos.domain.annotation.tissueAnnotation.service.TissueAnnotationService;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
+import site.pathos.domain.label.dto.LabelDto;
+import site.pathos.domain.label.service.LabelService;
 import site.pathos.domain.roi.dto.request.RoiRequestPayload;
 import site.pathos.domain.roi.dto.request.RoiSaveRequestDto;
 import site.pathos.domain.roi.entity.Roi;
@@ -21,9 +23,11 @@ public class RoiService {
     private final AnnotationHistoryRepository annotationHistoryRepository;
     private final RoiRepository roiRepository;
     private final TissueAnnotationService tissueAnnotationService;
+    private final LabelService labelService;
 
     @Transactional
-    public void saveWithAnnotations(Long subProjectId, Long annotationHistoryId, List<RoiSaveRequestDto> rois, List<MultipartFile> images) {
+    public void saveWithAnnotations(Long subProjectId, Long annotationHistoryId,
+                                    List<RoiSaveRequestDto> rois, List<MultipartFile> images, List<LabelDto> labels) {
         AnnotationHistory history = annotationHistoryRepository.findById(annotationHistoryId)
                 .orElseThrow(() -> new IllegalArgumentException("AnnotationHistory not found"));
 
@@ -41,6 +45,8 @@ public class RoiService {
                     matchedImages
             );
         }
+
+        labelService.upsertLabels(labels, history);
     }
 
     private Roi upsertRoi(AnnotationHistory history, RoiSaveRequestDto roiDto) {

--- a/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
+++ b/backend/src/main/java/site/pathos/domain/roi/service/RoiService.java
@@ -57,12 +57,16 @@ public class RoiService {
             return roi;
         } else {
             //새로 생긴 roi의 경우
+            Integer max = roiRepository.findMaxDisplayOrderByAnnotationHistory(history.getId());
+            int displayOrder = (max == null) ? 0 : max+1;
+
             Roi roi = Roi.builder()
                     .annotationHistory(history)
                     .x(roiDto.getX())
                     .y(roiDto.getY())
                     .width(roiDto.getWidth())
                     .height(roiDto.getHeight())
+                    .displayOrder(displayOrder)
                     .build();
             return roiRepository.save(roi);
         }

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -45,9 +45,13 @@ public class SubProject {
     @Column(name = "thumbnail_url")
     private String thumbnailUrl;
 
+    @Column(name = "is_upload_complete", nullable = false)
+    private boolean isUploadComplete;
+
     @Builder
     public SubProject(Project project) {
         this.project = project;
+        this.isUploadComplete = false;
     }
 
     public String initializeSvsImageUrl() {
@@ -69,5 +73,9 @@ public class SubProject {
             throw new IllegalStateException("SubProject ID must be set before initializing tileImageUrl.");
         }
         return this.tileImageUrl = String.format("sub-project/%s/tiles/output_slide.dzi", this.id);
+    }
+
+    public void markTilingCompleted() {
+        this.isUploadComplete = true;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
@@ -2,6 +2,7 @@ package site.pathos.domain.subProject.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import site.pathos.domain.annotationHistory.dto.response.AnnotationHistorySummaryDto;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
@@ -9,6 +10,7 @@ import site.pathos.domain.model.ModelSummaryDto;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.project.entity.Project;
 import site.pathos.domain.subProject.dto.response.SubProjectResponseDto;
+import site.pathos.domain.subProject.entity.SubProject;
 import site.pathos.domain.subProject.repository.SubProjectRepository;
 import site.pathos.domain.userModel.repository.UserModelRepository;
 
@@ -69,5 +71,13 @@ public class SubProjectService {
                 modelDtos,
                 project.getModelType()
         );
+    }
+
+    @Transactional
+    public void markTilingAsComplete(Long subProjectId){
+        SubProject subProject = subProjectRepository.findById(subProjectId)
+                .orElseThrow(() -> new IllegalArgumentException("SubProject not found: " + subProjectId));
+
+        subProject.markTilingCompleted();
     }
 }

--- a/backend/src/main/java/site/pathos/global/aws/config/AwsProperty.java
+++ b/backend/src/main/java/site/pathos/global/aws/config/AwsProperty.java
@@ -9,11 +9,14 @@ public record AwsProperty(
         @NotBlank String region,
         Credentials credentials,
         S3 s3,
-        Sqs sqs
+        Sqs sqs,
+        Callback callback
 ) {
     public record Credentials(@NotBlank String accessKey, @NotBlank String secretKey) {}
     public record S3(@NotBlank String bucket) {}
     public record Sqs(@NotBlank String queueUrl) {}
+
+    public record Callback(@NotBlank String url) {}
 
     public Region regionAsEnum() {
         return Region.of(region); // Region.of는 유효한 region 문자열만 허용

--- a/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
+++ b/backend/src/main/java/site/pathos/global/aws/ec2/Ec2Service.java
@@ -63,6 +63,7 @@ public class Ec2Service {
 
     private String generateUserDataScript(String s3Path, Long subProjectId) {
         String bucket = awsProperty.s3().bucket();
+        String callback = awsProperty.callback().url();
 
         return """
         #!/bin/bash
@@ -86,12 +87,15 @@ public class Ec2Service {
         aws s3 cp output_slide_files/ s3://%s/sub-project/%d/tiles/output_slide_files/ --recursive
         aws s3 cp thumbnail.jpg s3://%s/sub-project/%d/thumbnail/thumbnail.jpg
         
+        curl -X POST %s/internal/tiling-complete -H "Content-Type: application/json" -d '{"subProjectId": %d}'
+        
         shutdown -h now
         """.formatted(
                 s3Path,
                 bucket, subProjectId,
                 bucket, subProjectId,
-                bucket, subProjectId
+                bucket, subProjectId,
+                callback, subProjectId
         );
     }
 

--- a/backend/src/main/java/site/pathos/global/callback/CallbackController.java
+++ b/backend/src/main/java/site/pathos/global/callback/CallbackController.java
@@ -1,0 +1,24 @@
+package site.pathos.global.callback;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.pathos.domain.subProject.service.SubProjectService;
+import site.pathos.global.callback.dto.request.TilingCallbackRequestDto;
+
+@Hidden
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class CallbackController {
+
+    private final SubProjectService subProjectService;
+
+    @PostMapping("/tiling-complete")
+    public void tilingComplete(@RequestBody TilingCallbackRequestDto tilingCallbackRequestDto){
+        subProjectService.markTilingAsComplete(tilingCallbackRequestDto.subProjectId());
+    }
+}

--- a/backend/src/main/java/site/pathos/global/callback/dto/request/TilingCallbackRequestDto.java
+++ b/backend/src/main/java/site/pathos/global/callback/dto/request/TilingCallbackRequestDto.java
@@ -1,0 +1,6 @@
+package site.pathos.global.callback.dto.request;
+
+public record TilingCallbackRequestDto(
+        Long subProjectId
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #112 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 어노테이션 이미지 업로드 방식 변경
- ROI 크기만큼의 TISSUE 어노테이션 이미지를 업로드하던 방식을 동기처리에서 비동기 처리로 변경하였습니다
2. subproject, tissueAnotation 엔티티에 isUploadComplete 필드 추가
- 비동기 방식으로 이미지가 업로드 되기 때문에 업로드 완료 여부를 확인하기 위하여 필드로 처리했습니다.
- tissue annotation의 경우 Spring에서 모든 처리가 완료되기 때문에 내부 로직으로 처리하였으나
- sub project의 경우 다른 스팟 인스턴스에서 로직이 완료되기 때문에 API 호출 방식으로 처리하였습니다.
    -  이후에 확장성을 고려한다면 SQS를 활용한 방식으로 상태 체크를 하도록 리펙토링도 가능할 것 같습니다.
3. ROI 저장 시 Label 정보도 저장
아래는 roi 저장 json 예시입니다
```
{
  "subProjectId": 0,
  "annotationHistoryId": 0,
  "rois": [
    {
      "roiId": 0,
      "x": 0,
      "y": 0,
      "width": 0,
      "height": 0,
      "imageNames": [
        "string"
      ]
    }
  ],
  "images": [
    "string"
  ],
  "labels": [
    {
      "id": 0,
      "name": "string",
      "color": "string"
    }
  ]
}
```
- 다음과 같이 roi 저장 시 labels 정보도 같이 보내주시면 됩니다.
- 새로 생성한 roi의 경우 Id 값을 null로 주시면 됩니다
@hyeonjin6530 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
