### PR TITLE
[ BE ] docs/#114 스웨거 오류 해결 및 상세 설명(예시) 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:sqs:2.25.64'
 	implementation 'software.amazon.awssdk:ec2:2.25.64'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/CellDetail.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/CellDetail.java
@@ -1,4 +1,10 @@
 package site.pathos.domain.annotation.cellAnnotation.dto;
 
-public record CellDetail(int x, int y) {}
+import io.swagger.v3.oas.annotations.media.Schema;
 
+public record CellDetail(
+        @Schema(description = "세포의 X 좌표", example = "120")
+        int x,
+        @Schema(description = "세포의 Y 좌표", example = "340")
+        int y
+) {}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
@@ -1,5 +1,8 @@
 package site.pathos.domain.annotationHistory.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -9,21 +12,28 @@ import site.pathos.domain.annotationHistory.service.AnnotationHistoryService;
 @RestController
 @RequestMapping("/api/annotation-histories")
 @RequiredArgsConstructor
+@Tag(name = "Annotation History API", description = "어노테이션 히스토리 관리 API")
 public class AnnotationHistoryController {
 
     private final AnnotationHistoryService annotationHistoryService;
 
+    @Operation(summary = "모델 이름 수정", description = "Annotation History에 연결된 모델의 이름을 수정합니다.")
     @PatchMapping("/{annotationHistoryId}/model-name")
     public ResponseEntity<Void> updateModelName(
+            @Parameter(description = "Annotation History ID", example = "1")
             @PathVariable("annotationHistoryId") Long annotationHistoryId,
+
+            @Parameter(description = "수정할 모델 이름", example = "My Custom Model")
             @RequestParam("name") String modelName
     ) {
         annotationHistoryService.updateModelName(annotationHistoryId, modelName);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Annotation History 상세 조회", description = "특정 Annotation History의 상세 정보를 조회합니다.")
     @GetMapping("/{annotationHistoryId}")
     public ResponseEntity<AnnotationHistoryResponseDto> getAnnotationHistory(
+            @Parameter(description = "Annotation History ID", example = "1")
             @PathVariable("annotationHistoryId") Long annotationHistoryId) {
         AnnotationHistoryResponseDto response = annotationHistoryService.getAnnotationHistory(annotationHistoryId);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
@@ -1,13 +1,21 @@
 package site.pathos.domain.annotationHistory.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.label.dto.LabelDto;
 import site.pathos.domain.roi.dto.response.RoiResponsePayload;
 
 import java.util.List;
 
 public record AnnotationHistoryResponseDto(
+        @Schema(description = "Annotation History의 ID", example = "1")
         Long id,
+
+        @Schema(description = "연결된 모델의 이름", example = "My Custom Model")
         String modelName,
+
+        @Schema(description = "ROI 데이터 목록")
         List<RoiResponsePayload> roiPayloads,
+
+        @Schema(description = "Label 데이터 목록")
         List<LabelDto> labels
-) { }
+) {}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistorySummaryDto.java
@@ -1,11 +1,19 @@
 package site.pathos.domain.annotationHistory.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(description = "어노테이션 히스토리 요약 정보 DTO")
 public record AnnotationHistorySummaryDto(
+
+        @Schema(description = "히스토리 ID", example = "1001")
         Long id,
+        @Schema(description = "히스토리 순서", example = "1")
         int order,
+        @Schema(description = "히스토리 시작 시각", example = "2025-05-01T12:00:00")
         LocalDateTime startedAt,
+        @Schema(description = "히스토리 종료 시각", example = "2025-05-01T13:00:00")
         LocalDateTime completedAt
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/label/dto/LabelDto.java
+++ b/backend/src/main/java/site/pathos/domain/label/dto/LabelDto.java
@@ -1,8 +1,15 @@
 package site.pathos.domain.label.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record LabelDto(
+        @Schema(description = "라벨 ID. 생성 시 null, 수정 시 값 필요", example = "1")
         Long id,
+
+        @Schema(description = "라벨 이름", example = "Cancer Cell")
         String name,
+
+        @Schema(description = "라벨 색상 (HEX 코드)", example = "#FF5733")
         String color
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/model/ModelSummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/model/ModelSummaryDto.java
@@ -1,7 +1,14 @@
 package site.pathos.domain.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용 가능한 모델 요약 정보 DTO")
 public record ModelSummaryDto(
+
+        @Schema(description = "모델 ID", example = "1")
         Long id,
+
+        @Schema(description = "모델 이름", example = "TissueNet V2")
         String name
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
@@ -1,6 +1,9 @@
 package site.pathos.domain.modelServer.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,19 +13,28 @@ import site.pathos.domain.modelServer.service.ModelServerService;
 @RestController
 @RequestMapping("/api/model-server")
 @RequiredArgsConstructor
+@Tag(name = "Model Server API", description = "모델 학습 및 결과 전달 API")
 public class ModelServerController {
 
     private final ModelServerService modelServerService;
 
-    @PostMapping("/training")
-    public ResponseEntity<Void> requestTraining(@RequestParam("annotation_history_id") Long annotationHistoryId) {
+    @Operation(summary = "모델 학습 요청", description = "클라이언트가 모델 서버에 학습을 요청합니다.")
+    @PostMapping("/training/{annotationHistoryId}")
+    public ResponseEntity<Void> requestTraining(
+            @Parameter(description = "학습을 요청할 AnnotationHistory ID", required = true)
+            @PathVariable Long annotationHistoryId) {
         modelServerService.requestTraining(annotationHistoryId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/training/result")
-    public ResponseEntity<Void> responseTraining(@RequestBody TrainingResultRequestDto resultRequestDto){
-        modelServerService.resultTraining(resultRequestDto);
+    @PostMapping("/annotation-histories/{annotationHistoryId}/training/result")
+    @Operation(summary = "모델 학습 결과 수신", description = "모델 서버가 학습 결과를 서버에 전달합니다.")
+    public ResponseEntity<Void> responseTraining(
+            @Parameter(description = "어노테이션 히스토리 ID") @PathVariable Long annotationHistoryId,
+            @Parameter(description = "모델 학습 결과 데이터", required = true)
+            @RequestBody TrainingResultRequestDto resultRequestDto) {
+
+        modelServerService.resultTraining(annotationHistoryId, resultRequestDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
@@ -1,12 +1,16 @@
 package site.pathos.domain.modelServer.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.roi.dto.request.RoiRequestPayload;
 
 import java.util.List;
 
 public record TrainingResultRequestDto(
-        Long sub_project_id,
-        Long annotation_history_id,
+
+        @Schema(description = "학습된 모델이 저장된 경로", example = "s3://{bucket-name}/trained/model_101.pt", required = true)
         String model_path,
+
+        @Schema(description = "학습 결과 ROI 정보 리스트", required = true)
         List<RoiRequestPayload> roi
+
 ) { }

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -77,9 +77,9 @@ public class ModelServerService {
     }
 
     @Transactional
-    public void resultTraining(TrainingResultRequestDto resultRequestDto){
+    public void resultTraining(Long annotationHistoryId,TrainingResultRequestDto resultRequestDto){
         AnnotationHistory history = annotationHistoryRepository
-                .findWithSubProjectAndModelById(resultRequestDto.annotation_history_id())
+                .findWithSubProjectAndModelById(annotationHistoryId)
                 .orElseThrow(() -> new RuntimeException("history not found"));
 
         AnnotationHistory newHistory = AnnotationHistory.builder()
@@ -97,7 +97,7 @@ public class ModelServerService {
         modelService.saveModel(history, history.getModelName(), baseModel.getModelType() ,resultRequestDto.model_path());
 
         //TODO 모델서버에서 기능 추가시 수정 필요
-        inferenceHistoryService.updateInferenceHistory(resultRequestDto.annotation_history_id(),
+        inferenceHistoryService.updateInferenceHistory(annotationHistoryId,
                 0,
                 0,
                 0

--- a/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package site.pathos.domain.project.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,13 +34,19 @@ public class ProjectController {
 
     private final ProjectService projectService;
 
+    @Operation(
+            summary = "서브 프로젝트를 조회합니다.",
+            description = "해당 projectId를 기반으로 연결된 서브 프로젝트 정보를 반환합니다."
+    )
     @GetMapping("/annotation/{projectId}")
     public ResponseEntity<GetSubProjectResponseDto> getSubProject(
+            @Parameter(description = "조회할 프로젝트 ID", example = "1")
             @PathVariable Long projectId
     ) {
         GetSubProjectResponseDto response = projectService.getSubProject(projectId);
         return ResponseEntity.ok(response);
     }
+
 
     @Operation(summary = "프로젝트를 생성합니다.")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/backend/src/main/java/site/pathos/domain/project/dto/response/GetSubProjectResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/project/dto/response/GetSubProjectResponseDto.java
@@ -1,12 +1,20 @@
 package site.pathos.domain.project.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
 
 import java.util.List;
 
+@Schema(description = "프로젝트 상세에서 서브 프로젝트들을 조회할 때 사용하는 응답 DTO")
 public record GetSubProjectResponseDto(
+
+        @Schema(description = "프로젝트 ID", example = "1")
         Long projectId,
+
+        @Schema(description = "프로젝트 제목", example = "Upsilon Viz")
         String title,
+
+        @Schema(description = "서브 프로젝트 요약 정보 리스트")
         List<SubProjectSummaryDto> subProjects
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
+++ b/backend/src/main/java/site/pathos/domain/roi/controller/RoiController.java
@@ -1,14 +1,14 @@
 package site.pathos.domain.roi.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import site.pathos.domain.label.dto.LabelDto;
-import site.pathos.domain.roi.dto.request.RoiSaveRequestDto;
+import site.pathos.domain.roi.dto.request.RoiLabelSaveRequestDto;
 import site.pathos.domain.roi.service.RoiService;
 
 import java.util.List;
@@ -16,19 +16,31 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/rois")
 @RequiredArgsConstructor
+@Tag(name = "ROI API", description = "ROI 및 관련 이미지/라벨 업로드 기능 제공")
 public class RoiController {
 
     private final RoiService roiService;
 
-    @PostMapping
+    @PostMapping(
+            value = "/sub-projects/{subProjectId}/histories/{annotationHistoryId}",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
+    )
+    @Operation(summary = "ROI, 이미지, 라벨 업로드", description = "특정 SubProject와 AnnotationHistory에 ROI, 관련 이미지, 라벨 정보를 업로드합니다.")
     public ResponseEntity<Void> uploadRois(
-            @RequestPart("subProjectId") Long subProjectId,
-            @RequestPart("annotationHistoryId") Long annotationHistoryId,
-            @RequestPart("rois") List<RoiSaveRequestDto> rois,
-            @RequestPart("images") List<MultipartFile> images,
-            @RequestPart("labels") List<LabelDto> labels
-    ){
-        roiService.saveWithAnnotations(subProjectId, annotationHistoryId, rois, images, labels);
+            @Parameter(description = "서브 프로젝트 ID", required = true)
+            @PathVariable Long subProjectId,
+
+            @Parameter(description = "어노테이션 히스토리 ID", required = true)
+            @PathVariable Long annotationHistoryId,
+
+            @Parameter(description = "ROI, 라벨 정보 리스트", required = true)
+            @RequestPart("requestDto") RoiLabelSaveRequestDto roiLabelSaveRequestDto,
+
+            @Parameter(description = "ROI에 대응하는 이미지들", required = true)
+            @RequestPart("images") List<MultipartFile> images
+    ) {
+        roiService.saveWithAnnotations(subProjectId, annotationHistoryId,
+                roiLabelSaveRequestDto.rois(), images, roiLabelSaveRequestDto.labels());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiLabelSaveRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiLabelSaveRequestDto.java
@@ -1,0 +1,16 @@
+package site.pathos.domain.roi.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import site.pathos.domain.label.dto.LabelDto;
+
+import java.util.List;
+
+public record RoiLabelSaveRequestDto(
+
+        @Schema(description = "ROI 정보 리스트")
+        List<RoiSaveRequestDto> rois,
+
+        @Schema(description = "라벨 정보 리스트")
+        List<LabelDto> labels
+
+) {}

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestDto.java
@@ -1,9 +1,18 @@
 package site.pathos.domain.roi.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record RoiRequestDto(
+        @Schema(description = "ROI의 X 좌표", example = "120")
         int x,
+
+        @Schema(description = "ROI의 Y 좌표", example = "340")
         int y,
+
+        @Schema(description = "ROI의 너비", example = "512")
         int width,
+
+        @Schema(description = "ROI의 높이", example = "512")
         int height
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
@@ -1,12 +1,22 @@
 package site.pathos.domain.roi.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
 
 import java.util.List;
 
 public record RoiRequestPayload(
+
+        @Schema(description = "화면에 표시될 ROI 순서", example = "0")
         int displayOrder,
+
+        @Schema(description = "ROI 상세 정보")
         RoiRequestDto detail,
+
+        @Schema(description = "조직 이미지 경로 리스트", example = "[\"s3://{bucket-name}/sub-project/1/roi-1/tile1.jpg\"]")
         List<String> tissue_path,
+
+        @Schema(description = "세포 좌표 리스트")
         List<CellDetail> cell
+
 ) {}

--- a/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponseDto.java
@@ -1,10 +1,23 @@
 package site.pathos.domain.roi.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record RoiResponseDto(
+        @Schema(description = "ROI ID", example = "1")
         Long id,
+
+        @Schema(description = "ROI의 X 좌표", example = "100")
         int x,
+
+        @Schema(description = "ROI의 Y 좌표", example = "200")
         int y,
+
+        @Schema(description = "ROI의 너비", example = "512")
         int width,
+
+        @Schema(description = "ROI의 높이", example = "512")
         int height,
+
+        @Schema(description = "ROI의 결함 비율 (0.0 ~ 1.0)", example = "0.15")
         Double faulty
 ) {}

--- a/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponsePayload.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponsePayload.java
@@ -1,13 +1,24 @@
 package site.pathos.domain.roi.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
 
 import java.util.List;
 
 public record RoiResponsePayload(
+        @Schema(description = "ROI의 표시 순서", example = "1")
         int displayOrder,
+
+        @Schema(description = "ROI의 위치 및 크기 정보")
         RoiResponseDto detail,
+
+        @Schema(
+                description = "조직 주석 이미지 경로 목록",
+                example = "[\"sub-project/1/annotation-history/2/roi-3/train/tissue1.png\", \"sub-project/1/annotation-history/2/roi-3/train/tissue2.png\"]"
+        )
         List<String> tissue_path,
+
+        @Schema(description = "세포 위치 정보 목록")
         List<CellDetail> cell
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/controller/SubProjectController.java
@@ -1,15 +1,15 @@
 package site.pathos.domain.subProject.controller;
 
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.pathos.domain.subProject.dto.response.SubProjectResponseDto;
 import site.pathos.domain.subProject.service.SubProjectService;
 
+@Tag(name = "SubProject API", description = "서브 프로젝트 관련 API")
 @RestController
 @RequestMapping("/api/subprojects")
 @RequiredArgsConstructor
@@ -17,10 +17,12 @@ public class SubProjectController {
 
     private final SubProjectService subProjectService;
 
+    @Operation(summary = "서브 프로젝트 상세 조회", description = "서브 프로젝트 ID로 해당 서브 프로젝트의 상세 정보를 조회합니다.")
     @GetMapping("/{subProjectId}")
     public ResponseEntity<SubProjectResponseDto> getSubProject(
+            @Parameter(description = "조회할 서브 프로젝트의 ID", example = "1")
             @PathVariable("subProjectId") Long subProjectId
-    ){
+    ) {
         SubProjectResponseDto response = subProjectService.getSubProject(subProjectId);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectResponseDto.java
@@ -1,16 +1,27 @@
 package site.pathos.domain.subProject.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import site.pathos.domain.annotationHistory.dto.response.AnnotationHistorySummaryDto;
 import site.pathos.domain.model.ModelSummaryDto;
 import site.pathos.domain.model.entity.ModelType;
 
 import java.util.List;
 
+@Schema(description = "서브 프로젝트 상세 응답 DTO")
 public record SubProjectResponseDto(
+        @Schema(description = "서브 프로젝트 ID", example = "42")
         Long subProjectId,
+
+        @Schema(description = "어노테이션 히스토리 요약 정보 리스트")
         List<AnnotationHistorySummaryDto> annotationHistories,
+
+        @Schema(description = "가장 최근의 어노테이션 히스토리 ID", example = "101")
         Long latestAnnotationHistoryId,
+
+        @Schema(description = "선택 가능한 모델 리스트")
         List<ModelSummaryDto> availableModels,
+
+        @Schema(description = "모델 타입", example = "CELL")
         ModelType modelType
 ) {
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectSummaryDto.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/dto/response/SubProjectSummaryDto.java
@@ -1,7 +1,14 @@
 package site.pathos.domain.subProject.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "서브 프로젝트 요약 정보 DTO")
 public record SubProjectSummaryDto(
+
+        @Schema(description = "서브 프로젝트 ID", example = "101")
         Long subProjectId,
+
+        @Schema(description = "서브 프로젝트 썸네일 URL", example = "https://example.com/subproject-101/thumbnail.jpg")
         String thumbnailUrl
 ) {
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #114 

## 📝작업 내용

1. 스웨거 버전 수정
`GlobalExceptionHandler`에서 사용된 `@RestControllerAdvice`와 스웨거의 기존 버전이 충돌이 발생하여 아래의 버전으로 수정하였습니다.
`org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0` -> `org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0`

2. 스웨거 상세 설명 추가
- 스웨거에 상세 설명과 적절한 출력 예시들을 입력하였습니다.

3. API 경로 리펙토링
- 불필요한 request body나 dto에 적절하지 않은 구조, path 경로 등을 수정하였습니다.
- 기존에 작업하시던 API 연결이 있다면 PR이 완료된 이후 다시 배포된 버전으로 확인해주시면 감사하겠습니다.
@gyuwonsong @hyeonjin6530 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)