### PR TITLE
[ FE] feat/#92 어노테이션 기능 디벨롭

### DIFF
--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -619,16 +619,8 @@ const AnnotationViewer: React.FC<{
           ensureLabelForCurrentColor();
 
           if (!currentPolygonRef.current) {
-            const matchedROI = allROIs.find(
-              (roi) =>
-                viewportPoint.x >= roi.x &&
-                viewportPoint.x <= roi.x + roi.width &&
-                viewportPoint.y >= roi.y &&
-                viewportPoint.y <= roi.y + roi.height,
-            );
-            if (!matchedROI) return;
+            if (!isInsideAnyROI(viewportPoint)) return;
 
-            currentDrawingROIRef.current = matchedROI;
             currentPolygonRef.current = {
               points: [],
               closed: false,
@@ -660,16 +652,6 @@ const AnnotationViewer: React.FC<{
               return;
             }
           }
-          const polygonROI = currentDrawingROIRef.current;
-          if (
-            !polygonROI ||
-            viewportPoint.x < polygonROI.x ||
-            viewportPoint.x > polygonROI.x + polygonROI.width ||
-            viewportPoint.y < polygonROI.y ||
-            viewportPoint.y > polygonROI.y + polygonROI.height
-          ) {
-            return;
-          }
 
           currentPolygonRef.current.points.push(viewportPoint);
           redraw();
@@ -694,16 +676,8 @@ const AnnotationViewer: React.FC<{
             !currentCellPolygonRef.current ||
             currentCellPolygonRef.current.closed
           ) {
-            const matchedROI = allROIs.find(
-              (roi) =>
-                viewportPoint.x >= roi.x &&
-                viewportPoint.x <= roi.x + roi.width &&
-                viewportPoint.y >= roi.y &&
-                viewportPoint.y <= roi.y + roi.height,
-            );
-            if (!matchedROI) return;
+            if (!isInsideAnyROI(viewportPoint)) return;
 
-            currentDrawingROIRef.current = matchedROI;
             currentCellPolygonRef.current = {
               points: [],
               closed: false,
@@ -742,16 +716,6 @@ const AnnotationViewer: React.FC<{
               currentDrawingROIRef.current = null;
               return;
             }
-          }
-          const cellPolygonROI = currentDrawingROIRef.current;
-          if (
-            !cellPolygonROI ||
-            viewportPoint.x < cellPolygonROI.x ||
-            viewportPoint.x > cellPolygonROI.x + cellPolygonROI.width ||
-            viewportPoint.y < cellPolygonROI.y ||
-            viewportPoint.y > cellPolygonROI.y + cellPolygonROI.height
-          ) {
-            return;
           }
 
           currentCellPolygonRef.current.points.push(viewportPoint);

--- a/frontend/src/components/annotation/annotation-viewer/index.tsx
+++ b/frontend/src/components/annotation/annotation-viewer/index.tsx
@@ -23,11 +23,20 @@ import {
   drawROIs,
 } from '@/utils/canvas-roi-utils';
 import {
+  deepCopyRenderQueue,
   deepCopyStrokes,
+  deepCopyPolygons,
   drawStroke,
-  subtractStroke,
 } from '@/utils/canvas-drawing-utils';
-import { Point, Stroke, ROI, LoadedROI, Polygon } from '@/types/annotation';
+import {
+  Point,
+  Stroke,
+  ROI,
+  LoadedROI,
+  Polygon,
+  RenderItem,
+  RenderSnapshot,
+} from '@/types/annotation';
 import { SubProject } from '@/types/project-schema';
 import { dummyInferenceResults } from '@/data/dummy';
 import AnnotationSidebar from '@/components/annotation/annotation-sidebar';
@@ -74,9 +83,9 @@ const AnnotationViewer: React.FC<{
     polygonIndex: number;
     pointIndex: number;
   } | null>(null);
-  const isRedoingRef = useRef(false);
 
   // 드로잉 도구 관련 상태
+  const [renderQueueVersion, setRenderQueueVersion] = useState(0);
   const [penColor, setPenColor] = useState('#FF0000');
   const [penSize, setPenSize] = useState(10);
   const [mousePosition, setMousePosition] = useState<Point | null>(null);
@@ -98,8 +107,15 @@ const AnnotationViewer: React.FC<{
   const [cellPolygonsMap, setCellPolygonsMap] = useState<
     Record<number, Polygon[]>
   >({});
-  const [undoMap, setUndoMap] = useState<Record<number, Stroke[][]>>({});
-  const [redoMap, setRedoMap] = useState<Record<number, Stroke[][]>>({});
+  const [renderQueueMap, setRenderQueueMap] = useState<
+    Record<number, RenderItem[]>
+  >({});
+  const [renderQueueUndoMap, setRenderQueueUndoMap] = useState<
+    Record<number, RenderItem[][]>
+  >({});
+  const [renderQueueRedoMap, setRenderQueueRedoMap] = useState<
+    Record<number, RenderItem[][]>
+  >({});
 
   // 현재 서브프로젝트 ID 기준 상태 접근
   const subProjectId = subProject?.id ?? -1;
@@ -120,15 +136,12 @@ const AnnotationViewer: React.FC<{
     () => cellPolygonsMap[subProjectId] || [],
     [cellPolygonsMap, subProjectId],
   );
-
-  const undoStack = useMemo(
-    () => undoMap[subProjectId] || [],
-    [undoMap, subProjectId],
-  );
-  const redoStack = useMemo(
-    () => redoMap[subProjectId] || [],
-    [redoMap, subProjectId],
-  );
+  const [renderSnapshotUndoMap, setRenderSnapshotUndoMap] = useState<
+    Record<number, RenderSnapshot[]>
+  >({});
+  const [renderSnapshotRedoMap, setRenderSnapshotRedoMap] = useState<
+    Record<number, RenderSnapshot[]>
+  >({});
 
   // 현재 서브프로젝트 ID 기준 상태 업데이트 함수들
   const setUserDefinedROIs = (rois: ROI[]) => {
@@ -151,14 +164,34 @@ const AnnotationViewer: React.FC<{
     setCellPolygonsMap((prev) => ({ ...prev, [subProjectId]: polygons }));
   };
 
-  const setUndoStack = (s: Stroke[][]) => {
-    if (subProjectId == null) return;
-    setUndoMap((prev) => ({ ...prev, [subProjectId]: s }));
+  // 스냅샷 저장 함수
+  const pushRenderSnapshot = () => {
+    const snapshot: RenderSnapshot = {
+      renderQueue: deepCopyRenderQueue(renderQueueMap[subProjectId] || []),
+      strokes: deepCopyStrokes(strokesMap[subProjectId] || []),
+      polygons: deepCopyPolygons(polygonsMap[subProjectId] || []),
+    };
+
+    setRenderSnapshotUndoMap((prev) => ({
+      ...prev,
+      [subProjectId]: [...(prev[subProjectId] || []), snapshot],
+    }));
+    setRenderSnapshotRedoMap((prev) => ({
+      ...prev,
+      [subProjectId]: [],
+    }));
   };
 
-  const setRedoStack = (s: Stroke[][]) => {
-    if (subProjectId == null) return;
-    setRedoMap((prev) => ({ ...prev, [subProjectId]: s }));
+  // 스냅샷 복원 함수
+  const restoreRenderSnapshot = (snapshot: RenderSnapshot) => {
+    setRenderQueueMap((prev) => ({
+      ...prev,
+      [subProjectId]: snapshot.renderQueue,
+    }));
+    setStrokes(snapshot.strokes);
+    setPolygons(snapshot.polygons);
+    setRenderQueueVersion((v) => v + 1);
+    redraw();
   };
 
   /* =============================================
@@ -273,9 +306,6 @@ const AnnotationViewer: React.FC<{
     return null;
   };
 
-  /* =============================================
-        셀 폴리곤 점 클릭 감지 함수
-   ============================================== */
   const getClickedCellPolygonPoint = (x: number, y: number) => {
     if (!viewerInstance.current) return null;
     const threshold = 6;
@@ -450,9 +480,7 @@ const AnnotationViewer: React.FC<{
       viewerInstance.current,
       canvasRef,
       loadedROIs,
-      strokes,
-      currentStrokeRef.current,
-      polygons,
+      renderQueueMap[subProjectId] || [],
       currentPolygonRef.current,
       mousePosition,
     );
@@ -467,6 +495,7 @@ const AnnotationViewer: React.FC<{
         isInsideAnyROI,
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     viewerInstance,
     canvasRef,
@@ -476,6 +505,11 @@ const AnnotationViewer: React.FC<{
     cellPolygons,
     mousePosition,
   ]);
+
+  useEffect(() => {
+    redraw();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderQueueMap, strokesMap, polygonsMap, subProjectId]);
 
   const syncAllCanvases = useCallback(() => {
     if (!viewerInstance.current) return;
@@ -496,6 +530,7 @@ const AnnotationViewer: React.FC<{
         );
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     viewerInstance,
     canvasRef,
@@ -642,13 +677,39 @@ const AnnotationViewer: React.FC<{
               firstPixel.y - mousePixel.y,
             );
             if (dist < 10) {
-              currentPolygonRef.current.points.push(first);
-              currentPolygonRef.current.closed = true;
-              polygons.push(currentPolygonRef.current);
+              const closedPolygon = {
+                ...currentPolygonRef.current!,
+                closed: true,
+              };
+
+              // 현재 상태 스냅샷 저장
+              pushRenderSnapshot();
+
+              const prevRenderQueue = renderQueueMap[subProjectId] || [];
+              const updatedRenderQueue = [
+                ...prevRenderQueue,
+                { type: 'polygon', polygon: closedPolygon } as RenderItem,
+              ];
+
+              setRenderQueueMap((prev) => ({
+                ...prev,
+                [subProjectId]: updatedRenderQueue,
+              }));
+
+              setPolygons([...polygons, closedPolygon]);
+              setRenderSnapshotRedoMap((prev) => ({
+                ...prev,
+                [subProjectId]: [],
+              }));
+
+              setRenderQueueVersion((v) => v + 1);
+              redraw();
+
+              // 상태 정리
               currentPolygonRef.current = null;
               currentDrawingROIRef.current = null;
               setMousePosition(null);
-              redraw();
+
               return;
             }
           }
@@ -791,8 +852,7 @@ const AnnotationViewer: React.FC<{
         y: viewportPoint.y,
       });
 
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
+      const ctx = canvasRef.current.getContext('2d');
       if (!ctx) return;
       ctx.save();
       drawStroke(currentStrokeRef.current, viewerInstance.current, ctx);
@@ -931,42 +991,38 @@ const AnnotationViewer: React.FC<{
 
     // 드로잉 모드일 때
     if (isDrawingMode && currentStrokeRef.current) {
-      const isEraser = currentStrokeRef.current.isEraser;
-      const prevStrokes = deepCopyStrokes(strokes);
-      setUndoStack([...undoStack, prevStrokes]);
-      setRedoStack([]);
+      const newStroke = currentStrokeRef.current;
 
-      if (isEraser) {
-        const eraserStroke = currentStrokeRef.current;
+      // 현재 상태 스냅샷 저장
+      pushRenderSnapshot();
 
-        const pencilStrokes = strokes.filter((s) => !s.isEraser);
-        const oldEraserStrokes = strokes.filter((s) => s.isEraser);
+      const updatedRenderQueue = [
+        ...(renderQueueMap[subProjectId] || []),
+        { type: 'stroke', stroke: newStroke } as RenderItem,
+      ];
 
-        const updatedStrokes: Stroke[] = [];
+      setRenderQueueMap((prev) => ({
+        ...prev,
+        [subProjectId]: updatedRenderQueue,
+      }));
 
-        for (const pencilStroke of pencilStrokes) {
-          const segs = subtractStroke(
-            pencilStroke,
-            eraserStroke,
-            viewerInstance.current,
-            canvasRef.current,
-          );
-          updatedStrokes.push(...segs);
-        }
+      setStrokes([...strokes, newStroke]);
+      setRenderSnapshotRedoMap((prev) => ({
+        ...prev,
+        [subProjectId]: [],
+      }));
 
-        const newStrokes = [
-          ...updatedStrokes,
-          ...oldEraserStrokes,
-          eraserStroke,
-        ];
-
-        setStrokes(newStrokes);
-      } else {
-        setStrokes([...strokes, currentStrokeRef.current]);
-      }
+      setRenderQueueVersion((v) => v + 1);
+      redraw();
 
       currentStrokeRef.current = null;
-      redraw();
+
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx) {
+        ctx.save();
+        drawStroke(newStroke, viewerInstance.current, ctx);
+        ctx.restore();
+      }
     }
   };
 
@@ -997,8 +1053,8 @@ const AnnotationViewer: React.FC<{
     }
 
     if (!isDrawingMode) {
-      setUndoStack([]);
-      setRedoStack([]);
+      setRenderQueueUndoMap((prev) => ({ ...prev, [subProjectId]: [] }));
+      setRenderQueueRedoMap((prev) => ({ ...prev, [subProjectId]: [] }));
       setIsDrawingMode(true);
       setIsSelectingROI(false);
       setIsEditingROI(false);
@@ -1056,8 +1112,17 @@ const AnnotationViewer: React.FC<{
       const updatedROIs = [...userDefinedROIs];
       updatedROIs.splice(adjustedIndex, 1);
 
-      setUndoStack([...undoStack, deepCopyStrokes(strokes)]);
-      setRedoStack([]);
+      setRenderQueueUndoMap((prev) => ({
+        ...prev,
+        [subProjectId]: [
+          ...(prev[subProjectId] || []),
+          [...(renderQueueMap[subProjectId] || [])],
+        ],
+      }));
+      setRenderQueueRedoMap((prev) => ({
+        ...prev,
+        [subProjectId]: [],
+      }));
       setUserDefinedROIs(updatedROIs);
       setStrokes(filteredStrokes);
       setPolygons(filteredPolygons);
@@ -1109,39 +1174,80 @@ const AnnotationViewer: React.FC<{
   const handleReset = () => {
     if (!subProjectId) return;
 
-    setUndoStack([...undoStack, deepCopyStrokes(strokes)]);
-    setRedoStack([]);
+    // 현재 상태 스냅샷 저장
+    pushRenderSnapshot();
+
+    // 상태 초기화
+    setRenderQueueMap((prev) => ({
+      ...prev,
+      [subProjectId]: [],
+    }));
+
     setStrokes([]);
-    currentStrokeRef.current = null;
     setPolygons([]);
-    currentPolygonRef.current = null;
     setCellPolygons([]);
+    setRenderSnapshotRedoMap((prev) => ({
+      ...prev,
+      [subProjectId]: [],
+    }));
+
+    currentStrokeRef.current = null;
+    currentPolygonRef.current = null;
     currentCellPolygonRef.current = null;
     setROI(null);
+
+    setRenderQueueVersion((v) => v + 1);
     redraw();
   };
 
   const handleUndo = () => {
-    if (!subProjectId) return;
+    const undoStack = renderSnapshotUndoMap[subProjectId] || [];
     if (undoStack.length === 0) return;
 
-    const lastState = undoStack[undoStack.length - 1];
-    setRedoStack([...redoStack, deepCopyStrokes(strokes)]);
-    setStrokes(deepCopyStrokes(lastState));
-    setUndoStack(undoStack.slice(0, undoStack.length - 1));
-    redraw();
+    const lastSnapshot = undoStack[undoStack.length - 1];
+    setRenderSnapshotRedoMap((prev) => ({
+      ...prev,
+      [subProjectId]: [
+        ...(renderSnapshotRedoMap[subProjectId] || []),
+        {
+          renderQueue: deepCopyRenderQueue(renderQueueMap[subProjectId] || []),
+          strokes: deepCopyStrokes(strokesMap[subProjectId] || []),
+          polygons: deepCopyPolygons(polygonsMap[subProjectId] || []),
+        },
+      ],
+    }));
+
+    setRenderSnapshotUndoMap((prev) => ({
+      ...prev,
+      [subProjectId]: undoStack.slice(0, undoStack.length - 1),
+    }));
+
+    restoreRenderSnapshot(lastSnapshot);
   };
 
   const handleRedo = () => {
-    if (!subProjectId || isRedoingRef.current || redoStack.length === 0) return;
+    const redoStack = renderSnapshotRedoMap[subProjectId] || [];
+    if (redoStack.length === 0) return;
 
-    isRedoingRef.current = true;
-    const nextState = redoStack[redoStack.length - 1];
-    setUndoStack([...undoStack, deepCopyStrokes(strokes)]);
-    setStrokes(deepCopyStrokes(nextState));
-    setRedoStack(redoStack.slice(0, redoStack.length - 1));
-    redraw();
-    isRedoingRef.current = false;
+    const nextSnapshot = redoStack[redoStack.length - 1];
+    setRenderSnapshotUndoMap((prev) => ({
+      ...prev,
+      [subProjectId]: [
+        ...(renderSnapshotUndoMap[subProjectId] || []),
+        {
+          renderQueue: deepCopyRenderQueue(renderQueueMap[subProjectId] || []),
+          strokes: deepCopyStrokes(strokesMap[subProjectId] || []),
+          polygons: deepCopyPolygons(polygonsMap[subProjectId] || []),
+        },
+      ],
+    }));
+
+    setRenderSnapshotRedoMap((prev) => ({
+      ...prev,
+      [subProjectId]: redoStack.slice(0, redoStack.length - 1),
+    }));
+
+    restoreRenderSnapshot(nextSnapshot);
   };
 
   // ESC로 polygon 모드 취소 + ROI 리사이징 취소

--- a/frontend/src/types/annotation.ts
+++ b/frontend/src/types/annotation.ts
@@ -35,3 +35,13 @@ export interface LoadedROI {
   bbox: { x: number; y: number; w: number; h: number };
   tiles: MaskTile[];
 }
+
+export type RenderItem =
+  | { type: 'stroke'; stroke: Stroke }
+  | { type: 'polygon'; polygon: Polygon };
+
+export type RenderSnapshot = {
+  renderQueue: RenderItem[];
+  strokes: Stroke[];
+  polygons: Polygon[];
+};

--- a/frontend/src/utils/canvas-ploygon-utils.ts
+++ b/frontend/src/utils/canvas-ploygon-utils.ts
@@ -1,6 +1,9 @@
 import OpenSeadragon from 'openseadragon';
 import { Point, Polygon } from '@/types/annotation';
 
+/**
+ * 폴리곤 그리기
+ */
 export const drawPolygon = (
   viewerInstance: any,
   ctx: CanvasRenderingContext2D,
@@ -43,8 +46,27 @@ export const drawPolygon = (
 
   // 내부 색 채우기 (닫혀 있고 dashed 아님)
   if (isClosed && !dashed && points.length > 2) {
+    ctx.save();
+
+    // 폴리곤 경계 설정
+    ctx.beginPath();
+    ctx.moveTo(pixelPoints[0].x, pixelPoints[0].y);
+    for (let i = 1; i < pixelPoints.length; i++) {
+      ctx.lineTo(pixelPoints[i].x, pixelPoints[i].y);
+    }
+    ctx.closePath();
+
+    // 폴리곤 경계 내에서만 작업
+    ctx.clip();
+
+    // 알파 무시하고 덮어쓰기
+    ctx.globalCompositeOperation = 'source-over';
     ctx.fillStyle = color;
+
+    // fillRect 대신 다시 경계를 채움
     ctx.fill();
+
+    ctx.restore();
   }
 
   // 모든 점 그리기 (dashed 라면 항상, 아니면 isClosed가 아닐 때만)
@@ -80,6 +102,9 @@ export const drawPolygon = (
   ctx.restore();
 };
 
+/**
+ * 셀 폴리곤 그리기
+ */
 export const drawCellPolygons = (
   viewer: OpenSeadragon.Viewer,
   ctx: CanvasRenderingContext2D,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 일반 폴리곤, 셀 폴리곤 에러 Hotfix
ROI가 두 개 있다고 가정 했을 때 각기 다른 ROI를 넘나들며 폴리곤이 구현되던 이슈 발견 -> 폴리곤 첫 시작 시점의 ROI를 기억해두고, 그 ROI 내부에서만 추가 포인트를 허용하는 방식으로 제한
유저가 새로 생성한 ROI가 아니라, 기존에 있던 ROI만 있다고 가정했을 때 폴리곤이 찍히지 않는 이슈 발견 -> loadedROIs가 빈 배열일 때 fallback 처리되는 것을 발견 -> `isInsideAnyROI` 함수를 재사용하여 문제 해결

2. 지우개 작업 시 자동 보간 되던 것 수정
드로잉 지우개 작업 시 자동 보간되어 원하는 영역이 클리핑이 완벽히 되지 않았는데, png와 동일한 픽셀 삭제 기법을 적용함
다시 드로잉할 땐 이를 무시하는 옵션을 적용하여 드로잉 과정에 문제 없도록 해결함

3. 일반 폴리곤 지우개 구현
일반 폴리곤은 기존에 fill 방식으로 채워져 stroke를 잘라내는 지우개 방식에 동작하지 않음
첫 번째 시도로, png 지우기 방식에서 사용되는 픽셀 자체를 없애는 것을 적용하였음
지우개 상태 유지는 되었지만, `redrawCanvas` 의 렌더링 순서로 인해 지운 영역에 드로잉 / 폴리곤을 다시 하면 그 부분만 계속 클리핑 됨
추가로, 드로잉이 폴리곤보다 우선순위가 높게 렌더링되어 폴리곤을 생성해도 무조건 드로잉보다 밑에 깔림
드로잉 / 폴리곤 / 지우개 하나를 렌더링 큐로 관리하고 redraw 되도록 수정함

4. undo / redo / reset 로직 보완
기존 방식은 드로잉 Stroke만 스택으로 관리하고 있었으나 드로잉 / 폴리곤 / 지우개를 하나의 렌더링 큐로 관리하게 되면서 undo, redo, reset 도 기능적 보완 과정을 거침
deepcopy 함수를 별도로 선언하여 전후로의 상태 복원, 리셋 등이 가능함

### 스크린샷 (선택)

<img width="1582" alt="스크린샷 2025-05-12 오전 6 26 30" src="https://github.com/user-attachments/assets/9eeeaac3-35eb-4cf8-919d-72c1522ed096" />
<img width="1582" alt="스크린샷 2025-05-12 오전 6 26 43" src="https://github.com/user-attachments/assets/cd0680f6-a10b-4af2-83f9-5d5f6c033036" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

undo, redo 시 렌더링 큐 / stroke / polygon 이 deepcopy 되면서 (대량 데이터일 때) JSON.parse / JSON.stringify 의 병목 현상이 걱정이 됩니다. 최적화 시 상태가 바뀌지 않은 객체는 복사하지 않고 기존 참조 유지 -> 새로 바뀐 것만 스냅샷에 반영 (캐싱) 하는 방식을 도입하면 좋을 것 같습니다!