### PR TITLE
[ FE ] feat/#92 셀, 멀티 구현

### DIFF
--- a/frontend/src/app/main/projects/annotation/[id]/page.tsx
+++ b/frontend/src/app/main/projects/annotation/[id]/page.tsx
@@ -6,9 +6,27 @@ import dynamic from 'next/dynamic';
 import {
   dummyProjects,
   dummySubProject,
-  dummyInferenceResults,
+  dummyCellInferenceResults,
+  dummyTissueInferenceResults,
+  dummyMultiInferenceResults,
 } from '@/data/dummy';
 import { Project, SubProject } from '@/types/project-schema';
+
+const getInferenceResultByModelType = (
+  modelType: string,
+  selectedSubProjectId: number,
+) => {
+  const resultList =
+    {
+      CELL: dummyCellInferenceResults,
+      TISSUE: dummyTissueInferenceResults,
+      MULTI: dummyMultiInferenceResults,
+    }[modelType] || [];
+
+  return (
+    resultList.find((res) => res.subProjectId === selectedSubProjectId) ?? null
+  );
+};
 
 /* 뷰어는 동적 import */
 const AnnotationViewer = dynamic(
@@ -18,7 +36,12 @@ const AnnotationViewer = dynamic(
   subProject: SubProject | null;
   setSubProject: (sp: SubProject) => void;
   subProjects: SubProject[];
-  inferenceResult: (typeof dummyInferenceResults)[number] | null;
+  inferenceResult:
+    | (typeof dummyCellInferenceResults)[number]
+    | (typeof dummyTissueInferenceResults)[number]
+    | (typeof dummyMultiInferenceResults)[number]
+    | null;
+  modelType: string;
 }>;
 
 export default function ProjectAnnotationPage() {
@@ -48,13 +71,9 @@ export default function ProjectAnnotationPage() {
   }, [id]);
 
   const selectedInferenceResult = useMemo(() => {
-    if (!selected) return null;
-
-    return (
-      dummyInferenceResults.find((res) => res.subProjectId === selected.id) ??
-      null
-    );
-  }, [selected]);
+    if (!project || !selected) return null;
+    return getInferenceResultByModelType(project.modelType, selected.id);
+  }, [project, selected]);
 
   if (!ready) return <p>Loading…</p>;
   if (!project) return <p>잘못된 프로젝트 ID입니다.</p>;
@@ -70,6 +89,7 @@ export default function ProjectAnnotationPage() {
           setSubProject={setSelected}
           subProjects={subProjects}
           inferenceResult={selectedInferenceResult}
+          modelType={project.modelType}
         />
       ) : (
         <p>서브프로젝트를 선택하세요.</p>

--- a/frontend/src/components/annotation/annotation-cell-delete-modal/index.tsx
+++ b/frontend/src/components/annotation/annotation-cell-delete-modal/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface AnnotationCellDeleteModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirmDelete: () => void;
+}
+
+const AnnotationCellDeleteModal: React.FC<AnnotationCellDeleteModalProps> = ({
+  open,
+  onClose,
+  onConfirmDelete,
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Cell Polygon</DialogTitle>
+        </DialogHeader>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Are you sure you want to delete{' '}
+          <span className="font-semibold">this polygon</span>? This action
+          cannot be undone.
+        </p>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose} className="min-w-[80px]">
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirmDelete}
+            className="min-w-[80px]"
+          >
+            Delete
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AnnotationCellDeleteModal;

--- a/frontend/src/components/annotation/annotation-model-export-modal/index.tsx
+++ b/frontend/src/components/annotation/annotation-model-export-modal/index.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface AnnotationModelExportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (modelName: string) => void;
+}
+
+const AnnotationModelExportModal: React.FC<AnnotationModelExportModalProps> = ({
+  open,
+  onClose,
+  onSave,
+}) => {
+  const [modelName, setModelName] = useState('');
+
+  const handleSave = () => {
+    if (modelName.trim()) {
+      onSave(modelName.trim());
+      setModelName('');
+      onClose();
+    }
+  };
+
+  const handleCancel = () => {
+    setModelName('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleCancel}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export Model</DialogTitle>
+        </DialogHeader>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Enter a name to export this model. <br />
+          You can reuse this model in other projects to save time and effort.{' '}
+          <br />
+          Optionally, you can share this model in the{' '}
+          <span className="font-semibold">Public Space</span> to help others
+          benefit from your work.
+        </p>
+        <Input
+          placeholder="Enter model name"
+          value={modelName}
+          onChange={(e) => setModelName(e.target.value)}
+          className="mt-2"
+        />
+        <div className="mt-4 flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            className="min-w-[80px]"
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSave} className="min-w-[80px]">
+            Save
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AnnotationModelExportModal;

--- a/frontend/src/components/annotation/annotation-tool/index.tsx
+++ b/frontend/src/components/annotation/annotation-tool/index.tsx
@@ -6,6 +6,7 @@ import {
   Eraser,
   Palette,
   SlidersHorizontal,
+  XCircle,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { HexColorPicker } from 'react-colorful';
@@ -14,8 +15,10 @@ import { Slider } from '@/components/ui/slider';
 interface AnnotationToolProps {
   modelType: string;
   isActive: boolean;
-  activeTool: 'point' | 'polygon' | 'paintbrush' | 'eraser' | null;
-  onSelectTool: (tool: 'point' | 'polygon' | 'paintbrush' | 'eraser') => void;
+  activeTool: 'point' | 'polygon' | 'paintbrush' | 'eraser' | 'delete' | null;
+  onSelectTool: (
+    tool: 'point' | 'polygon' | 'paintbrush' | 'eraser' | 'delete',
+  ) => void;
   penColor: string;
   penSize: number;
   onChangePenColor: (color: string) => void;
@@ -68,14 +71,24 @@ const AnnotationTool: React.FC<AnnotationToolProps> = ({
     switch (modelType) {
       case 'CELL':
         return (
-          <Button
-            variant={'ghost'}
-            size={'icon'}
-            onClick={() => onSelectTool('point')}
-            className={activeTool === 'point' ? 'bg-primary text-white' : ''}
-          >
-            <CircleDot />
-          </Button>
+          <>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => onSelectTool('point')}
+              className={activeTool === 'point' ? 'bg-primary text-white' : ''}
+            >
+              <CircleDot />
+            </Button>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
+              onClick={() => onSelectTool('delete')}
+              className={activeTool === 'delete' ? 'bg-primary text-white' : ''}
+            >
+              <XCircle />
+            </Button>
+          </>
         );
       case 'TISSUE':
         return (
@@ -144,6 +157,14 @@ const AnnotationTool: React.FC<AnnotationToolProps> = ({
             <Button
               variant={'ghost'}
               size={'icon'}
+              onClick={() => onSelectTool('delete')}
+              className={activeTool === 'delete' ? 'bg-primary text-white' : ''}
+            >
+              <XCircle />
+            </Button>
+            <Button
+              variant={'ghost'}
+              size={'icon'}
               onClick={() => onSelectTool('eraser')}
               className={activeTool === 'eraser' ? 'bg-primary text-white' : ''}
             >
@@ -187,32 +208,36 @@ const AnnotationTool: React.FC<AnnotationToolProps> = ({
         )}
       </div>
 
-      {/* 펜 크기 선택 */}
-      <Button
-        ref={sizeButtonRef}
-        variant="ghost"
-        size="icon"
-        onClick={() => setPenSizeMenuOpen((prev) => !prev)}
-      >
-        <SlidersHorizontal />
-      </Button>
+      {modelType !== 'CELL' && (
+        <>
+          {/* 펜 크기 선택 */}
+          <Button
+            ref={sizeButtonRef}
+            variant="ghost"
+            size="icon"
+            onClick={() => setPenSizeMenuOpen((prev) => !prev)}
+          >
+            <SlidersHorizontal />
+          </Button>
 
-      {/* 펜 크기 Slider */}
-      {penSizeMenuOpen && (
-        <div
-          ref={sizeMenuRef}
-          className="absolute bottom-0 left-full z-50 ml-2 flex flex-col items-center gap-3 rounded-lg bg-white p-4 shadow"
-        >
-          <Slider
-            orientation="vertical"
-            min={5}
-            max={50}
-            step={1}
-            value={[penSize]}
-            onValueChange={([val]) => onChangePenSize(val)}
-            className="h-32 w-4"
-          />
-        </div>
+          {/* 펜 크기 Slider */}
+          {penSizeMenuOpen && (
+            <div
+              ref={sizeMenuRef}
+              className="absolute bottom-0 left-full z-50 ml-2 flex flex-col items-center gap-3 rounded-lg bg-white p-4 shadow"
+            >
+              <Slider
+                orientation="vertical"
+                min={5}
+                max={50}
+                step={1}
+                value={[penSize]}
+                onValueChange={([val]) => onChangePenSize(val)}
+                className="h-32 w-4"
+              />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/data/dummy.ts
+++ b/frontend/src/data/dummy.ts
@@ -33,38 +33,38 @@ export const dummyAnnotationHistory: AnnotationHistory[] = [
 export const dummyProjects: Project[] = [
   {
     id: 1,
-    title: 'Alpha Analysis',
+    title: 'Cell Test',
     description: 'Initial tissue analysis project.',
     userId: 1,
     modelId: 1,
     createdAt: '2025-03-01T09:00:00Z',
     updatedAt: '2025-03-01T12:00:00Z',
     history: dummyAnnotationHistory,
-    modelType: 'TISSUE',
+    modelType: 'CELL',
     modelNameList: ['PathOs-v1', 'PathOs-v2', 'CustomModel-A'],
   },
   {
     id: 2,
-    title: 'Beta Segmentation',
+    title: 'Tissue Test',
     description: 'Multi-region segmentation project.',
     userId: 2,
     modelId: 2,
     createdAt: '2025-03-02T10:00:00Z',
     updatedAt: '2025-03-02T13:30:00Z',
     history: dummyAnnotationHistory,
-    modelType: 'MULTI',
-    modelNameList: [],
+    modelType: 'TISSUE',
+    modelNameList: ['PathOs-v1', 'PathOs-v2', 'CustomModel-A'],
   },
   {
     id: 3,
-    title: 'Gamma Classification',
+    title: 'Multi Test',
     description: 'Cell classification benchmark.',
     userId: 3,
     modelId: 3,
     createdAt: '2025-03-03T11:00:00Z',
     updatedAt: '2025-03-03T15:00:00Z',
     history: dummyAnnotationHistory,
-    modelType: 'CELL',
+    modelType: 'MULTI',
     modelNameList: [],
   },
   {
@@ -301,7 +301,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 45,
-    projectId: '1',
+    projectId: '2',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.5,
@@ -309,7 +309,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 46,
-    projectId: '1',
+    projectId: '2',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.3,
@@ -317,7 +317,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 47,
-    projectId: '1',
+    projectId: '2',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.6,
@@ -325,7 +325,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 48,
-    projectId: '1',
+    projectId: '3',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.5,
@@ -333,7 +333,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 49,
-    projectId: '1',
+    projectId: '3',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.3,
@@ -341,55 +341,7 @@ export const dummySubProject: SubProject[] = [
   },
   {
     id: 50,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.6,
-    uploadedOn: '2025-04-02T14:00:00Z',
-  },
-  {
-    id: 51,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.5,
-    uploadedOn: '2025-03-31T12:30:00Z',
-  },
-  {
-    id: 52,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.3,
-    uploadedOn: '2025-04-01T13:00:00Z',
-  },
-  {
-    id: 53,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.6,
-    uploadedOn: '2025-04-02T14:00:00Z',
-  },
-  {
-    id: 54,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.5,
-    uploadedOn: '2025-03-31T12:30:00Z',
-  },
-  {
-    id: 55,
-    projectId: '1',
-    svsPath: '/svs_example.svs',
-    thumbnail: '/subproject-thumbnail.png',
-    size: 1.3,
-    uploadedOn: '2025-04-01T13:00:00Z',
-  },
-  {
-    id: 56,
-    projectId: '1',
+    projectId: '3',
     svsPath: '/svs_example.svs',
     thumbnail: '/subproject-thumbnail.png',
     size: 1.6,
@@ -397,73 +349,77 @@ export const dummySubProject: SubProject[] = [
   },
 ];
 
-// 인퍼런스 히스토리 더미 데이터
-export const dummyInferenceHistory: InferenceHistory = {
-  id: 12,
-  accuracy: 0.9375,
-  loss: 0.1642,
-  loopPerformance: 0.82,
-};
-
-// 모델 더미 데이터
-export const dummyModel: Model = {
-  id: 5,
-  annotationHistoryId: 88,
-  name: 'Example Model',
-  modelType: 'CELL' as ModelType,
-  modelVersion: 'v1.0',
-  trainedAt: '2025-03-30T10:00:00Z',
-};
-
-// ROI 더미 데이터 (추후 어노테이션 및 export 기능에 활용)
-export const dummyROI: ROI = {
-  id: 101,
-  annotationHistoryId: 88,
-  x: 120,
-  y: 85,
-  width: 200,
-  height: 200,
-};
-
-// Tissue Annotation 더미 데이터
-export const dummyTissueAnnotation: TissueAnnotation = {
-  id: 1,
-  roiId: 101,
-  imagePath: 'tissue_annotation_image.png',
-};
-
-// Cell Annotation 더미 데이터
-export const dummyCellAnnotation: CellAnnotation = {
-  id: 1,
-  roiId: 101,
-  x: 150,
-  y: 100,
-  radius: 15,
-  color: '#ff0000',
-  label: 'Cell A',
-};
-
 // 모델 추론 결과 응답 더미 데이터
-export const dummyInferenceResults = [
+export const dummyCellInferenceResults = [
   {
-    inferenceId: 12,
+    id: 1,
+    modelName: 'Cell Model',
     annotationHistoryId: 88,
     subProjectId: 42,
     modelId: 5,
-    metrics: {
-      accuracy: 0.9375,
-      loss: 0.1642,
-      loopPerformance: 0.82,
-    },
-    completedAt: '2025-04-01T03:14:00Z',
-    results: [
+    roiPayloads: [
       {
-        roiId: 101,
-        x: 63465,
-        y: 11220,
-        width: 31248,
-        height: 27978,
-        maskUrl: [
+        displayOrder: 1,
+        detail: {
+          id: 101,
+          x: 63465,
+          y: 11220,
+          width: 31248,
+          height: 27978,
+          faulty: 0.15,
+        },
+        tissue_path: [],
+        cell: [
+          {
+            color: '#FFFF00',
+            points: [
+              { x: 83640.66, y: 21111.9 },
+              { x: 80579.89, y: 22688.66 },
+              { x: 80626.26, y: 26213.18 },
+              { x: 83779.78, y: 27418.94 },
+              { x: 85727.55, y: 25192.93 },
+            ],
+          },
+          {
+            color: '#0000FF',
+            points: [
+              { x: 69496.19, y: 20509.02 },
+              { x: 66991.93, y: 22271.28 },
+              { x: 67084.68, y: 25146.55 },
+              { x: 70423.7, y: 27140.69 },
+              { x: 72556.96, y: 24126.3 },
+              { x: 71675.83, y: 21761.16 },
+            ],
+          },
+        ],
+      },
+    ],
+    labels: [
+      { id: 1, name: 'Test A', color: '#FFFF00' },
+      { id: 2, name: 'Test B', color: '#0000FF' },
+    ],
+  },
+];
+
+export const dummyTissueInferenceResults = [
+  {
+    id: 1,
+    modelName: 'Tissue Model',
+    annotationHistoryId: 88,
+    subProjectId: 45,
+    modelId: 5,
+    roiPayloads: [
+      {
+        displayOrder: 1,
+        detail: {
+          id: 101,
+          x: 63465,
+          y: 11220,
+          width: 31248,
+          height: 27978,
+          faulty: 0.15,
+        },
+        tissue_path: [
           '/0_0.png',
           '/0_1.png',
           '/0_2.png',
@@ -471,7 +427,68 @@ export const dummyInferenceResults = [
           '/1_1.png',
           '/1_2.png',
         ],
+        cell: [],
       },
+    ],
+    labels: [{ id: 1, name: 'Test C', color: '#FF0000' }],
+  },
+];
+
+export const dummyMultiInferenceResults = [
+  {
+    id: 1,
+    modelName: 'Tissue Model',
+    annotationHistoryId: 88,
+    subProjectId: 48,
+    modelId: 5,
+    roiPayloads: [
+      {
+        displayOrder: 1,
+        detail: {
+          id: 101,
+          x: 63465,
+          y: 11220,
+          width: 31248,
+          height: 27978,
+          faulty: 0.15,
+        },
+        tissue_path: [
+          '/0_0.png',
+          '/0_1.png',
+          '/0_2.png',
+          '/1_0.png',
+          '/1_1.png',
+          '/1_2.png',
+        ],
+        cell: [
+          {
+            color: '#FFFF00',
+            points: [
+              { x: 83640.66, y: 21111.9 },
+              { x: 80579.89, y: 22688.66 },
+              { x: 80626.26, y: 26213.18 },
+              { x: 83779.78, y: 27418.94 },
+              { x: 85727.55, y: 25192.93 },
+            ],
+          },
+          {
+            color: '#0000FF',
+            points: [
+              { x: 69496.19, y: 20509.02 },
+              { x: 66991.93, y: 22271.28 },
+              { x: 67084.68, y: 25146.55 },
+              { x: 70423.7, y: 27140.69 },
+              { x: 72556.96, y: 24126.3 },
+              { x: 71675.83, y: 21761.16 },
+            ],
+          },
+        ],
+      },
+    ],
+    labels: [
+      { id: 1, name: 'Test A', color: '#FFFF00' },
+      { id: 2, name: 'Test B', color: '#0000FF' },
+      { id: 3, name: 'Test C', color: '#FF0000' },
     ],
   },
 ];

--- a/frontend/src/stores/annotation-shared.ts
+++ b/frontend/src/stores/annotation-shared.ts
@@ -1,15 +1,20 @@
 import { create } from 'zustand';
-import { ROI, LoadedROI } from '@/types/annotation';
+import { ROI, LoadedROI, Polygon } from '@/types/annotation';
+import { Label } from '@/types/annotation-sidebar';
 
 interface AnnotationSharedState {
   viewer: OpenSeadragon.Viewer | null;
   canvas: HTMLCanvasElement | null;
   loadedROIs: LoadedROI[];
   userDefinedROIs: ROI[];
+  cellPolygons: Polygon[];
+  labels: Label[];
   setViewer: (viewer: OpenSeadragon.Viewer | null) => void;
   setCanvas: (canvas: HTMLCanvasElement | null) => void;
   setLoadedROIs: (rois: LoadedROI[]) => void;
   setUserDefinedROIs: (rois: ROI[]) => void;
+  setCellPolygons: (polygons: Polygon[]) => void;
+  setLabels: (labels: Label[]) => void;
 }
 
 export const useAnnotationSharedStore = create<AnnotationSharedState>(
@@ -18,9 +23,13 @@ export const useAnnotationSharedStore = create<AnnotationSharedState>(
     canvas: null,
     loadedROIs: [],
     userDefinedROIs: [],
+    cellPolygons: [],
+    labels: [],
     setViewer: (viewer) => set({ viewer }),
     setCanvas: (canvas) => set({ canvas }),
     setLoadedROIs: (rois) => set({ loadedROIs: rois }),
     setUserDefinedROIs: (rois) => set({ userDefinedROIs: rois }),
+    setCellPolygons: (polygons) => set({ cellPolygons: polygons }),
+    setLabels: (labels) => set({ labels }),
   }),
 );

--- a/frontend/src/types/annotation.ts
+++ b/frontend/src/types/annotation.ts
@@ -33,7 +33,11 @@ export interface MaskTile {
 
 export interface LoadedROI {
   bbox: { x: number; y: number; w: number; h: number };
-  tiles: MaskTile[];
+  tiles?: MaskTile[];
+  points?: { x: number; y: number }[];
+  label?: string;
+  color?: string;
+  cells?: Polygon[];
 }
 
 export type RenderItem =

--- a/frontend/src/utils/canvas-ploygon-utils.ts
+++ b/frontend/src/utils/canvas-ploygon-utils.ts
@@ -1,5 +1,5 @@
 import OpenSeadragon from 'openseadragon';
-import { Point, Polygon } from '@/types/annotation';
+import { LoadedROI, Point, Polygon } from '@/types/annotation';
 
 /**
  * 폴리곤 그리기
@@ -136,4 +136,42 @@ export const drawCellPolygons = (
   });
 
   ctx.restore();
+};
+
+export const drawCellInferencePoints = (
+  viewer: OpenSeadragon.Viewer,
+  ctx: CanvasRenderingContext2D,
+  loadedROIs: LoadedROI[],
+) => {
+  loadedROIs.forEach((roi) => {
+    if (roi.points && roi.points.length > 0) {
+      // 기존 유틸 함수 재사용 (닫힌 폴리곤 + 점선 스타일 적용)
+      drawPolygon(
+        viewer,
+        ctx,
+        roi.points.map((pt) =>
+          viewer.viewport.imageToViewportCoordinates(
+            new OpenSeadragon.Point(pt.x, pt.y),
+          ),
+        ),
+        null,
+        roi.color || '#FF0000',
+        true,
+        true,
+      );
+
+      // 각 포인트에 원형 점 추가
+      roi.points.forEach((pt) => {
+        const viewportPt = viewer.viewport.imageToViewportCoordinates(
+          new OpenSeadragon.Point(pt.x, pt.y),
+        );
+        const pixelPt = viewer.viewport.pixelFromPoint(viewportPt);
+
+        ctx.beginPath();
+        ctx.arc(pixelPt.x, pixelPt.y, 3, 0, 2 * Math.PI);
+        ctx.fillStyle = roi.color || '#FF0000';
+        ctx.fill();
+      });
+    }
+  });
 };

--- a/frontend/src/utils/canvas-utils.ts
+++ b/frontend/src/utils/canvas-utils.ts
@@ -2,7 +2,11 @@ import OpenSeadragon from 'openseadragon';
 import React from 'react';
 import { LoadedROI, Polygon, Point, RenderItem } from '@/types/annotation';
 import { drawStroke } from '@/utils/canvas-drawing-utils';
-import { drawCellPolygons, drawPolygon } from '@/utils/canvas-ploygon-utils';
+import {
+  drawCellInferencePoints,
+  drawCellPolygons,
+  drawPolygon,
+} from '@/utils/canvas-ploygon-utils';
 
 /**
  * 뷰어와 캔버스 동기화
@@ -69,7 +73,9 @@ export const redrawCanvas = (
   }
 
   /* ========= 1. 모든 ROI의 PNG 타일만 표시 ========= */
-  loadedROIs.forEach(({ tiles }) =>
+  loadedROIs.forEach(({ tiles }) => {
+    if (!tiles || tiles.length === 0) return;
+
     tiles.forEach(({ img, x, y, w, h }) => {
       const tlImg = new OpenSeadragon.Point(x, y);
       const brImg = new OpenSeadragon.Point(x + w, y + h);
@@ -81,8 +87,8 @@ export const redrawCanvas = (
       ctx.save();
       ctx.drawImage(img, p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
       ctx.restore();
-    }),
-  );
+    });
+  });
 
   /* ========= 2. 드로잉, 폴리곤, 지우개를 하나의 큐로 렌더링 ========= */
   renderQueue.forEach((item) => {
@@ -129,6 +135,7 @@ export const redrawCellCanvas = (
   current: Polygon | null,
   mouse: Point | null,
   isInsideAnyROI: (point: Point) => boolean,
+  loadedROIs: LoadedROI[],
 ) => {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
@@ -145,4 +152,6 @@ export const redrawCellCanvas = (
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
   drawCellPolygons(viewer, ctx, cellPolygons, current, mouse, isInsideAnyROI);
+
+  drawCellInferencePoints(viewer, ctx, loadedROIs);
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 셀, 멀티 구현
셀 폴리곤 수정 - 시프트 + 클릭
셀 폴리곤 삭제 - 더블클릭 -> 모달
셀 폴리곤 삭제의 경우 `activeTool` 을 변경하지 않으면 셀 폴리곤이 또 그려지는 이슈로, 별도의 delete 버튼을 추가했습니다
`modelType`이 `Cell`, `Multi`일 때 셀 폴리곤 모두 정상 동작합니다

2. 헤더 액션 추가
모델 성능 저장 플로우를 아예 헤더에 Export 버튼을 두어 모달처리 했습니다

3. zustand 상태관리 등록
viewer와 canvas 상태 외에 현재 로딩된 ROI, 유저가 생성한 ROI, 셀 폴리곤, label 정보를 넘기도록 설정해 두었습니다
### 스크린샷 (선택)

- 셀 구현 (`/main/projects/annotation/1`)
<img width="1582" alt="스크린샷 2025-05-12 오후 4 40 56" src="https://github.com/user-attachments/assets/a32450e3-0038-46fc-8815-2efbae6d840e" />

- 티슈 구현 (`/main/projects/annotation/2`)
<img width="1582" alt="스크린샷 2025-05-12 오후 4 40 30" src="https://github.com/user-attachments/assets/3223f5c6-79c1-4055-aa2d-96bda5a1e98f" />
<img width="966" alt="스크린샷 2025-05-12 오후 4 40 19" src="https://github.com/user-attachments/assets/59b69f94-2e52-4c18-8260-73ac55b3e90f" />

- 멀티 구현 (`/main/projects/annotation/3`)
<img width="1538" alt="스크린샷 2025-05-12 오후 4 43 06" src="https://github.com/user-attachments/assets/a664f150-3bf1-43ed-8476-df9eaacc765c" />
<img width="966" alt="스크린샷 2025-05-12 오후 4 43 17" src="https://github.com/user-attachments/assets/816a569d-5895-485e-9cf5-3f6980e02d5e" />

- 셀 폴리곤 삭제 (더블 클릭)
<img width="1582" alt="스크린샷 2025-05-12 오후 4 50 35" src="https://github.com/user-attachments/assets/92c7d518-fe03-4ec0-9ca3-ee1a831989e1" />
<img width="1582" alt="스크린샷 2025-05-12 오후 4 50 39" src="https://github.com/user-attachments/assets/4d335483-ace0-49dd-b3f1-cc4786f892ab" />

- 모델 Export
<img width="1582" alt="스크린샷 2025-05-12 오후 4 50 45" src="https://github.com/user-attachments/assets/93bec699-d04c-47d9-a172-4a50608ba6f1" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 티슈, 멀티 부분 성능저하가 너무 심각합니다 ^^... 구현 끝났으니 최적화 진행해 보겠습니다! 좋은 방법 생각나시면 추천 부탁드립니다 🤔 
- 백엔드 응답에 맞추어 최대한 더미 구성은 해 두었는데 히스토리를 타고 들어가는 방식이라 약간의 수정이 필요합니다. 참고 부탁드립니다! @hyeonjin6530 
- 현재 zustand로 `loadedROIs` 와 `userDefinedROIs` 를 별도로 보내고 있습니다. 완전 기획 초반에 나왔던 이야긴데 플래그로 판단해서 다시 학습요청 들어가지 않아도 되는 ROI를 판단할 때 쓰일까 봐 아직은 분리해둔 상태입니다. 어떤식으로 활용할 수 있을 지 더 고민해 보겠습니다.