### PR TITLE
[ BE ] feat/#120 프로젝트 기반 학습 구조 및 모델 관리 개선

### DIFF
--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/CellDetail.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/CellDetail.java
@@ -2,9 +2,16 @@ package site.pathos.domain.annotation.cellAnnotation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "세포 어노테이션 정보")
 public record CellDetail(
-        @Schema(description = "세포의 X 좌표", example = "120")
-        int x,
-        @Schema(description = "세포의 Y 좌표", example = "340")
-        int y
+
+        @Schema(description = "세포 클래스 인덱스", example = "0")
+        int classIndex,
+
+        @Schema(description = "세포 색상 (Hex)", example = "#FF0000")
+        String color,
+
+        @Schema(description = "세포 외곽 폴리곤 정보")
+        PolygonDto polygon
+
 ) {}

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/PolygonDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/dto/PolygonDto.java
@@ -1,0 +1,24 @@
+package site.pathos.domain.annotation.cellAnnotation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Polygon 좌표 정보")
+public record PolygonDto(
+
+        @Schema(description = "꼭짓점 좌표 리스트", example = "[{\"x\":123,\"y\":456}, {\"x\":124,\"y\":457}]")
+        List<PointDto> points
+
+) {
+    @Schema(description = "2D 평면 상의 좌표")
+    public record PointDto(
+
+            @Schema(description = "X 좌표", example = "123")
+            int x,
+
+            @Schema(description = "Y 좌표", example = "456")
+            int y
+    ) {}
+}
+

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
@@ -31,6 +31,6 @@ public class CellAnnotation {
     @Column(name = "color", nullable = false)
     private String color;
 
-    @Column(name = "label", nullable = false)
-    private String label;
+    @Column(name = "class_index", nullable = false)
+    private int classIndex;
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
@@ -47,4 +47,12 @@ public class CellAnnotation {
             this.y = y;
         }
     }
+
+    @Builder
+    public CellAnnotation(Roi roi, int classIndex, String color, List<Point> polygon){
+        this.roi = roi;
+        this.classIndex = classIndex;
+        this.color = color;
+        this.polygon = polygon;
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/entity/CellAnnotation.java
@@ -2,15 +2,19 @@ package site.pathos.domain.annotation.cellAnnotation.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.pathos.domain.roi.entity.Roi;
+
+import java.util.List;
 
 @Entity
 @Table(name = "cell_annotation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CellAnnotation {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -19,18 +23,28 @@ public class CellAnnotation {
     @JoinColumn(name = "roi_id", nullable = false)
     private Roi roi;
 
-    @Column(name = "x", nullable = false)
-    private int x;
-
-    @Column(name = "y", nullable = false)
-    private int y;
-
-    @Column(name = "radius", nullable = false)
-    private float radius;
+    @Column(name = "class_index", nullable = false)
+    private int classIndex;
 
     @Column(name = "color", nullable = false)
     private String color;
 
-    @Column(name = "class_index", nullable = false)
-    private int classIndex;
+    @ElementCollection
+    @CollectionTable(name = "cell_annotation_point",
+            joinColumns = @JoinColumn(name = "cell_annotation_id"))
+    private List<Point> polygon;
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor
+    public static class Point {
+        private int x;
+        private int y;
+
+        @Builder
+        public Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/repository/CellAnnotationRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/cellAnnotation/repository/CellAnnotationRepository.java
@@ -13,4 +13,6 @@ public interface CellAnnotationRepository extends JpaRepository<CellAnnotation, 
     FROM CellAnnotation ca
     WHERE ca.roi.id = :roiId""")
     List<CellAnnotation> findAllByRoiId(@Param("roiId") Long roiId);
+
+    List<CellAnnotation> findAllByRoiIdIn(List<Long> roiIds);
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/AnnotationType.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/AnnotationType.java
@@ -3,5 +3,5 @@ package site.pathos.domain.annotation.tissueAnnotation.entity;
 public enum AnnotationType {
     TILE,
     MERGED,
-    RESULT_TILE
+    RESULT
 }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/entity/TissueAnnotation.java
@@ -20,8 +20,8 @@ public class TissueAnnotation {
     @JoinColumn(name = "roi_id", nullable = false)
     private Roi roi;
 
-    @Column(name = "annotation_image_url", nullable = false)
-    private String annotationImageUrl;
+    @Column(name = "annotation_image_path", nullable = false)
+    private String annotationImagePath;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "annotation_type", nullable = false)
@@ -31,12 +31,12 @@ public class TissueAnnotation {
     private boolean isUploadComplete;
 
     @Builder
-    public TissueAnnotation(Roi roi, String annotationImageUrl, AnnotationType annotationType) {
+    public TissueAnnotation(Roi roi, String annotationImagePath, AnnotationType annotationType) {
         if (roi == null) throw new IllegalArgumentException("roi cannot be null in TissueAnnotation");
         if (annotationType == null) throw new IllegalArgumentException("annotationType is required");
 
         this.roi = roi;
-        this.annotationImageUrl = annotationImageUrl;
+        this.annotationImagePath = annotationImagePath;
         this.annotationType = annotationType;
         this.isUploadComplete = false;
     }

--- a/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/repository/TissueAnnotationRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/tissueAnnotation/repository/TissueAnnotationRepository.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 @Repository
 public interface TissueAnnotationRepository extends JpaRepository<TissueAnnotation, Long> {
-    @Query("SELECT ta FROM TissueAnnotation ta WHERE ta.roi.annotationHistory.id = :historyId AND ta.annotationType = :type")
-    List<TissueAnnotation> findMergedByAnnotationHistoryId(@Param("historyId") Long historyId, @Param("type") AnnotationType type);
+    @Query("SELECT t FROM TissueAnnotation t WHERE t.roi.id = :roiId")
+    List<TissueAnnotation> findByRoiId(@Param("roiId") Long roiId);
+
+    List<TissueAnnotation> findByRoiIdInAndAnnotationType(List<Long> roiIds, AnnotationType annotationType);
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/controller/AnnotationHistoryController.java
@@ -17,19 +17,6 @@ public class AnnotationHistoryController {
 
     private final AnnotationHistoryService annotationHistoryService;
 
-    @Operation(summary = "모델 이름 수정", description = "Annotation History에 연결된 모델의 이름을 수정합니다.")
-    @PatchMapping("/{annotationHistoryId}/model-name")
-    public ResponseEntity<Void> updateModelName(
-            @Parameter(description = "Annotation History ID", example = "1")
-            @PathVariable("annotationHistoryId") Long annotationHistoryId,
-
-            @Parameter(description = "수정할 모델 이름", example = "My Custom Model")
-            @RequestParam("name") String modelName
-    ) {
-        annotationHistoryService.updateModelName(annotationHistoryId, modelName);
-        return ResponseEntity.noContent().build();
-    }
-
     @Operation(summary = "Annotation History 상세 조회", description = "특정 Annotation History의 상세 정보를 조회합니다.")
     @GetMapping("/{annotationHistoryId}")
     public ResponseEntity<AnnotationHistoryResponseDto> getAnnotationHistory(

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
@@ -10,9 +10,6 @@ public record AnnotationHistoryResponseDto(
         @Schema(description = "Annotation History의 ID", example = "1")
         Long id,
 
-        @Schema(description = "연결된 모델의 이름", example = "My Custom Model")
-        String modelName,
-
         @Schema(description = "ROI 데이터 목록")
         List<RoiResponsePayload> roiPayloads
 ) {}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/dto/response/AnnotationHistoryResponseDto.java
@@ -14,8 +14,5 @@ public record AnnotationHistoryResponseDto(
         String modelName,
 
         @Schema(description = "ROI 데이터 목록")
-        List<RoiResponsePayload> roiPayloads,
-
-        @Schema(description = "Label 데이터 목록")
-        List<LabelDto> labels
+        List<RoiResponsePayload> roiPayloads
 ) {}

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -1,14 +1,11 @@
 package site.pathos.domain.annotationHistory.entity;
 
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import site.pathos.domain.label.entity.Label;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.subProject.entity.SubProject;
 
@@ -35,12 +32,13 @@ public class AnnotationHistory {
     @Column(name = "model_name", nullable = false)
     private String modelName;
 
-    @OneToMany(mappedBy = "annotationHistory", fetch = FetchType.LAZY)
-    private List<Label> labels = new ArrayList<>();
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
 
     @CreationTimestamp
-    @Column(name = "started_at", nullable = false)
-    private LocalDateTime startedAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     @Column(name = "completed_at")
     private LocalDateTime completedAt;

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import site.pathos.domain.inferenceHistory.entity.TrainingHistory;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.subProject.entity.SubProject;
 
@@ -26,11 +27,12 @@ public class AnnotationHistory {
     private SubProject subProject;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "training_history_id")
+    private TrainingHistory trainingHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "model_id")
     private Model model;
-
-    @Column(name = "model_name", nullable = false)
-    private String modelName;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -44,16 +46,8 @@ public class AnnotationHistory {
     private LocalDateTime completedAt;
 
     @Builder
-    public AnnotationHistory(SubProject subProject, Model model, String modelName) {
+    public AnnotationHistory(SubProject subProject, Model model) {
         this.subProject = subProject;
         this.model = model;
-        this.modelName = modelName;
-    }
-
-    public void updateModelName(String newName) {
-        if (newName == null || newName.trim().isEmpty()) {
-            throw new IllegalArgumentException("Model name must not be empty");
-        }
-        this.modelName = newName;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/entity/AnnotationHistory.java
@@ -46,8 +46,9 @@ public class AnnotationHistory {
     private LocalDateTime completedAt;
 
     @Builder
-    public AnnotationHistory(SubProject subProject, Model model) {
+    public AnnotationHistory(SubProject subProject, Model model, TrainingHistory trainingHistory) {
         this.subProject = subProject;
         this.model = model;
+        this.trainingHistory = trainingHistory;
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/repository/AnnotationHistoryRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.subProject.entity.SubProject;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,10 +25,16 @@ public interface AnnotationHistoryRepository extends JpaRepository<AnnotationHis
 
     @Query("""
         SELECT DISTINCT ah FROM AnnotationHistory ah
-        LEFT JOIN FETCH ah.labels
         WHERE ah IN :annotationHistories
     """)
-    List<AnnotationHistory> fetchAnnotationHistoriesAndLabels(
+    List<AnnotationHistory> fetchAnnotationHistories(
             @Param("annotationHistories") List<AnnotationHistory> annotationHistories
     );
+
+    @Query("""
+    SELECT ah FROM AnnotationHistory ah
+    WHERE ah.subProject.id = :subProjectId
+    ORDER BY ah.updatedAt DESC
+""")
+    Optional<AnnotationHistory> findLatestBySubProjectId(@Param("subProjectId") Long subProjectId);
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
@@ -10,8 +10,6 @@ import site.pathos.domain.annotation.tissueAnnotation.entity.TissueAnnotation;
 import site.pathos.domain.annotationHistory.dto.response.AnnotationHistoryResponseDto;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
-import site.pathos.domain.label.dto.LabelDto;
-import site.pathos.domain.label.entity.Label;
 import site.pathos.domain.label.repository.LabelRepository;
 import site.pathos.domain.roi.dto.response.RoiResponseDto;
 import site.pathos.domain.roi.dto.response.RoiResponsePayload;
@@ -67,17 +65,10 @@ public class AnnotationHistoryService {
                 })
                 .toList();
 
-        List<Label> labels = labelRepository.findByAnnotationHistoryId(historyId);
-
-        List<LabelDto> labelDtos = labels.stream()
-                .map(Label::toLabelDto)
-                .toList();
-
         return new AnnotationHistoryResponseDto(
                 history.getId(),
                 history.getModelName(),
-                roiPayloads,
-                labelDtos
+                roiPayloads
         );
     }
 }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
@@ -30,14 +30,6 @@ public class AnnotationHistoryService {
 
     private final S3Service s3Service;
 
-    @Transactional
-    public void updateModelName(Long annotationHistoryId, String newModelName) {
-        AnnotationHistory history = annotationHistoryRepository.findById(annotationHistoryId)
-                .orElseThrow(() -> new IllegalArgumentException("AnnotationHistory not found"));
-
-        history.updateModelName(newModelName);
-    }
-
     @Transactional(readOnly = true)
     public AnnotationHistoryResponseDto getAnnotationHistory(Long historyId) {
         AnnotationHistory history = annotationHistoryRepository.findWithSubProjectAndModelById(historyId)
@@ -67,7 +59,6 @@ public class AnnotationHistoryService {
 
         return new AnnotationHistoryResponseDto(
                 history.getId(),
-                history.getModelName(),
                 roiPayloads
         );
     }

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
@@ -3,6 +3,7 @@ package site.pathos.domain.annotationHistory.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.annotation.cellAnnotation.dto.PolygonDto;
 import site.pathos.domain.annotation.cellAnnotation.repository.CellAnnotationRepository;
 import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
 import site.pathos.domain.annotation.cellAnnotation.entity.CellAnnotation;
@@ -42,7 +43,15 @@ public class AnnotationHistoryService {
                     List<CellAnnotation> cellAnnotations = cellAnnotationRepository.findAllByRoiId(roi.getId());
 
                     List<CellDetail> cellDetails = cellAnnotations.stream()
-                            .map(ca -> new CellDetail(ca.getX(), ca.getY()))
+                            .map(ca -> new CellDetail(
+                                    ca.getClassIndex(),
+                                    ca.getColor(),
+                                    new PolygonDto(
+                                            ca.getPolygon().stream()
+                                                    .map(p -> new PolygonDto.PointDto(p.getX(), p.getY()))
+                                                    .toList()
+                                    )
+                            ))
                             .toList();
 
                     RoiResponseDto detail = new RoiResponseDto(

--- a/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/annotationHistory/service/AnnotationHistoryService.java
@@ -58,7 +58,7 @@ public class AnnotationHistoryService {
                             roi.getId(), roi.getX(), roi.getY(), roi.getWidth(), roi.getHeight(), roi.getFaulty());
 
                     List<String> presignedTissuePaths = roi.getTissueAnnotations().stream()
-                            .map(TissueAnnotation::getAnnotationImageUrl)
+                            .map(TissueAnnotation::getAnnotationImagePath)
                             .map(s3Service::getPresignedUrl)
                             .toList();
 

--- a/backend/src/main/java/site/pathos/domain/dataSet/entity/DataSet.java
+++ b/backend/src/main/java/site/pathos/domain/dataSet/entity/DataSet.java
@@ -20,8 +20,8 @@ public class DataSet {
     @JoinColumn(name = "shared_project_id", nullable = false)
     private SharedProject sharedProject;
 
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
+    @Column(name = "image_path", nullable = false)
+    private String imagePath;
 
     @Column(name = "data_type", nullable = false)
     private DataType dataType;

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/InferenceHistory.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/InferenceHistory.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.project.entity.Project;
 
 import java.time.LocalDateTime;
 
@@ -21,8 +23,12 @@ public class InferenceHistory {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "annotation_history_id", nullable = false)
-    private AnnotationHistory annotationHistory;
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "base_model_id", nullable = false)
+    private Model baseModel;
 
     @Column(name = "accuracy")
     private Float accuracy;
@@ -34,16 +40,18 @@ public class InferenceHistory {
     private Float loopPerformance;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
     @Builder
-    public InferenceHistory(AnnotationHistory annotationHistory){
-        this.annotationHistory = annotationHistory;
+    public InferenceHistory(Project project, Model model){
+        this.project = project;
+        this.baseModel = model;
     }
+
 
     public void updateResult(float accuracy, float loss, float loopPerformance) {
         this.accuracy = accuracy;

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/TrainingHistory.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/TrainingHistory.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.project.entity.Project;
 
@@ -26,7 +25,7 @@ public class TrainingHistory {
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "base_model_id")
+    @JoinColumn(name = "base_model_id", nullable = false)
     private Model baseModel;
 
     @CreationTimestamp

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/TrainingHistory.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/entity/TrainingHistory.java
@@ -1,0 +1,44 @@
+package site.pathos.domain.inferenceHistory.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.project.entity.Project;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "training_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainingHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "base_model_id")
+    private Model baseModel;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+
+    @Builder
+    public TrainingHistory(Project project, Model model){
+        this.project = project;
+        this.baseModel = model;
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/InferenceHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/InferenceHistoryRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 
 @Repository
 public interface InferenceHistoryRepository extends JpaRepository<InferenceHistory, Long> {
-    Optional<InferenceHistory> findByAnnotationHistoryId(Long annotationHistoryId);
 }

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/TrainingHistoryRepository.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/repository/TrainingHistoryRepository.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.inferenceHistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.pathos.domain.inferenceHistory.entity.TrainingHistory;
+
+public interface TrainingHistoryRepository extends JpaRepository<TrainingHistory, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/service/InferenceHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/service/InferenceHistoryService.java
@@ -6,26 +6,22 @@ import org.springframework.transaction.annotation.Transactional;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.inferenceHistory.entity.InferenceHistory;
 import site.pathos.domain.inferenceHistory.repository.InferenceHistoryRepository;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.project.entity.Project;
 
 @Service
 @RequiredArgsConstructor
 public class InferenceHistoryService {
+
     private final InferenceHistoryRepository inferenceHistoryRepository;
 
     @Transactional
-    public void saveInferenceHistory(AnnotationHistory annotationHistory){
+    public InferenceHistory createInferenceHistory(Project project, Model model) {
         InferenceHistory inferenceHistory = InferenceHistory.builder()
-                .annotationHistory(annotationHistory)
+                .project(project)
+                .model(model)
                 .build();
 
-        inferenceHistoryRepository.save(inferenceHistory);
-    }
-
-    @Transactional
-    public void updateInferenceHistory(Long annotationHistoryId, float accuracy, float loss, float loopPerformance) {
-        InferenceHistory history = inferenceHistoryRepository.findByAnnotationHistoryId(annotationHistoryId)
-                .orElseThrow(() -> new RuntimeException("InferenceHistory not found"));
-
-        history.updateResult(accuracy, loss, loopPerformance);
+        return inferenceHistoryRepository.save(inferenceHistory);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/inferenceHistory/service/TrainingHistoryService.java
+++ b/backend/src/main/java/site/pathos/domain/inferenceHistory/service/TrainingHistoryService.java
@@ -1,0 +1,26 @@
+package site.pathos.domain.inferenceHistory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.pathos.domain.inferenceHistory.entity.TrainingHistory;
+import site.pathos.domain.inferenceHistory.repository.TrainingHistoryRepository;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.project.entity.Project;
+
+@Service
+@RequiredArgsConstructor
+public class TrainingHistoryService {
+
+    private final TrainingHistoryRepository trainingHistoryRepository;
+
+    @Transactional
+    public TrainingHistory createTrainingHistory(Project project, Model model) {
+        TrainingHistory trainingHistory = TrainingHistory.builder()
+                .project(project)
+                .model(model)
+                .build();
+
+        return trainingHistoryRepository.save(trainingHistory);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/label/entity/Label.java
+++ b/backend/src/main/java/site/pathos/domain/label/entity/Label.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.label.dto.LabelDto;
+import site.pathos.domain.model.entity.Model;
 
 @Entity
 @Table(name = "label")
@@ -18,35 +19,4 @@ public class Label {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", nullable = false)
-    private String name;
-
-    @Column(name = "color", nullable = false)
-    private String color;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private AnnotationHistory annotationHistory;
-
-    @Builder
-    public Label(String name, String color, AnnotationHistory annotationHistory) {
-        this.name = name;
-        this.color = color;
-        this.annotationHistory = annotationHistory;
-    }
-
-    public void changeName(String name) {
-        this.name = name;
-    }
-
-    public void changeColor(String color) {
-        this.color = color;
-    }
-
-    public LabelDto toLabelDto() {
-        return new LabelDto(
-                id,
-                name,
-                color
-        );
-    }
 }

--- a/backend/src/main/java/site/pathos/domain/label/entity/ModelProjectLabel.java
+++ b/backend/src/main/java/site/pathos/domain/label/entity/ModelProjectLabel.java
@@ -1,0 +1,37 @@
+package site.pathos.domain.label.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.pathos.domain.model.entity.Model;
+
+@Entity
+@Table(
+        name = "model_label",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"model_id", "class_index"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ModelProjectLabel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "model_id", nullable = false)
+    private Model model;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_label_id", nullable = false)
+    private ProjectLabel projectLabel;
+
+    @Column(name = "class_index", nullable = false)
+    private Integer classIndex;
+
+    @Builder
+    public ModelProjectLabel(Model model, ProjectLabel projectLabel, Integer classIndex){
+        this.model = model;
+        this.projectLabel = projectLabel;
+        this.classIndex = classIndex;
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/label/entity/ProjectLabel.java
+++ b/backend/src/main/java/site/pathos/domain/label/entity/ProjectLabel.java
@@ -1,0 +1,44 @@
+package site.pathos.domain.label.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.pathos.domain.project.entity.Project;
+
+@Entity
+@Table(
+        name = "project_label",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"project_id", "label_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectLabel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "label_id", nullable = false)
+    private Label label;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "color", nullable = false)
+    private String color;
+
+    @Builder
+    public ProjectLabel(Project project, Label label, String name, String color){
+        this.project = project;
+        this.label = label;
+        this.name = name;
+        this.color = color;
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/label/repository/LabelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/label/repository/LabelRepository.java
@@ -6,5 +6,4 @@ import site.pathos.domain.label.entity.Label;
 import java.util.List;
 
 public interface LabelRepository extends JpaRepository<Label, Long> {
-    List<Label> findByAnnotationHistoryId(Long annotationHistoryId);
 }

--- a/backend/src/main/java/site/pathos/domain/label/repository/ModelProjectLabelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/label/repository/ModelProjectLabelRepository.java
@@ -1,0 +1,18 @@
+package site.pathos.domain.label.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.pathos.domain.label.entity.ModelProjectLabel;
+
+import java.util.List;
+
+public interface ModelProjectLabelRepository extends JpaRepository<ModelProjectLabel, Long> {
+    @Query("""
+    SELECT ml FROM ModelProjectLabel ml
+    JOIN FETCH ml.projectLabel pl
+    WHERE ml.model.id = :modelId
+    AND pl.project.id = :projectId
+""")
+    List<ModelProjectLabel> findByModelIdAndProjectId(@Param("modelId") Long modelId, @Param("projectId") Long projectId);
+}

--- a/backend/src/main/java/site/pathos/domain/label/repository/ProjectLabelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/label/repository/ProjectLabelRepository.java
@@ -1,0 +1,10 @@
+package site.pathos.domain.label.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.pathos.domain.label.entity.ProjectLabel;
+
+import java.util.List;
+
+public interface ProjectLabelRepository extends JpaRepository<ProjectLabel, Long> {
+    List<ProjectLabel> findAllByProjectId(Long projectId);
+}

--- a/backend/src/main/java/site/pathos/domain/label/service/LabelService.java
+++ b/backend/src/main/java/site/pathos/domain/label/service/LabelService.java
@@ -16,25 +16,4 @@ public class LabelService {
 
     private final LabelRepository labelRepository;
 
-    @Transactional
-    public void upsertLabels(List<LabelDto> labelDtos, AnnotationHistory history) {
-        for (LabelDto dto : labelDtos) {
-            if (dto.id() == null) {
-                // 신규 생성
-                Label newLabel = Label.builder()
-                        .name(dto.name())
-                        .color(dto.color())
-                        .annotationHistory(history)
-                        .build();
-                labelRepository.save(newLabel);
-            } else {
-                // 기존 항목 수정
-                Label existingLabel = labelRepository.findById(dto.id())
-                        .orElseThrow(() -> new IllegalArgumentException("Label not found: " + dto.id()));
-
-                existingLabel.changeName(dto.name());
-                existingLabel.changeColor(dto.color());
-            }
-        }
-    }
 }

--- a/backend/src/main/java/site/pathos/domain/model/Repository/ModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/Repository/ModelRepository.java
@@ -1,18 +1,9 @@
 package site.pathos.domain.model.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.pathos.domain.model.entity.Model;
 
-import java.util.Optional;
-
 @Repository
 public interface ModelRepository extends JpaRepository<Model, Long> {
-    @Query("""
-    SELECT m
-    FROM Model m
-    WHERE m.annotationHistory.id = :annotationHistoryId""")
-    Optional<Model> findByAnnotationHistoryId(@Param("annotationHistoryId") Long annotationHistoryId);
 }

--- a/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
@@ -1,7 +1,20 @@
 package site.pathos.domain.model.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.model.entity.ProjectModel;
 
+import java.util.List;
+
 public interface ProjectModelRepository extends JpaRepository<ProjectModel, Long> {
+    @Query("""
+    SELECT pm
+    FROM ProjectModel pm
+    JOIN FETCH pm.model
+    WHERE pm.project.id = :projectId
+    ORDER BY pm.createdAt ASC
+""")
+    List<ProjectModel> findByProjectIdOrderByCreatedAt(@Param("projectId") Long projectId);
 }

--- a/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
@@ -1,0 +1,7 @@
+package site.pathos.domain.model.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.pathos.domain.model.entity.ProjectModel;
+
+public interface ProjectModelRepository extends JpaRepository<ProjectModel, Long> {
+}

--- a/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/Repository/ProjectModelRepository.java
@@ -7,6 +7,7 @@ import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.model.entity.ProjectModel;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectModelRepository extends JpaRepository<ProjectModel, Long> {
     @Query("""
@@ -17,4 +18,12 @@ public interface ProjectModelRepository extends JpaRepository<ProjectModel, Long
     ORDER BY pm.createdAt ASC
 """)
     List<ProjectModel> findByProjectIdOrderByCreatedAt(@Param("projectId") Long projectId);
+
+    @Query("""
+    SELECT pm FROM ProjectModel pm
+    JOIN FETCH pm.model
+    WHERE pm.project.id = :projectId
+    ORDER BY pm.createdAt DESC
+""")
+    Optional<ProjectModel> findLatestByProjectIdWithModel(@Param("projectId") Long projectId);
 }

--- a/backend/src/main/java/site/pathos/domain/model/entity/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/Model.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.inferenceHistory.entity.TrainingHistory;
 
 import java.time.LocalDateTime;
 
@@ -20,8 +21,8 @@ public class Model {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "annotation_history_id")
-    private AnnotationHistory annotationHistory;
+    @JoinColumn(name = "training_history_id")
+    private TrainingHistory trainingHistory;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -37,8 +38,8 @@ public class Model {
     private LocalDateTime trainedAt;
 
     @Builder
-    public Model(AnnotationHistory annotationHistory, String name, ModelType modelType, String modelPath) {
-        this.annotationHistory = annotationHistory;
+    public Model(TrainingHistory trainingHistory, String name, ModelType modelType, String modelPath) {
+        this.trainingHistory = trainingHistory;
         this.name = name;
         this.modelType = modelType;
         this.modelPath = modelPath;

--- a/backend/src/main/java/site/pathos/domain/model/entity/Model.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/Model.java
@@ -30,18 +30,44 @@ public class Model {
     @Column(name = "model_type", nullable = false)
     private ModelType modelType;
 
-    @Column(name = "model_path", nullable = false)
-    private String modelPath;
+    @Column(name = "tissue_model_path")
+    private String tissueModelPath;
+
+    @Column(name = "cell_model_path")
+    private String cellModelPath;
 
     @CreationTimestamp
     @Column(name = "trained_at", nullable = false)
     private LocalDateTime trainedAt;
 
     @Builder
-    public Model(TrainingHistory trainingHistory, String name, ModelType modelType, String modelPath) {
+    public Model(TrainingHistory trainingHistory, String name,
+                 ModelType modelType, String tissueModelPath, String cellModelPath) {
         this.trainingHistory = trainingHistory;
         this.name = name;
         this.modelType = modelType;
-        this.modelPath = modelPath;
+
+        if (modelType == ModelType.CELL) {
+            if (cellModelPath == null) {
+                throw new IllegalArgumentException("SINGLE_CELL 모델은 cellModelPath가 필요합니다.");
+            }
+            this.cellModelPath = cellModelPath;
+            this.tissueModelPath = null;
+        } else if (modelType == ModelType.TISSUE) {
+            if (tissueModelPath == null) {
+                throw new IllegalArgumentException("SINGLE_TISSUE 모델은 tissueModelPath가 필요합니다.");
+            }
+            this.tissueModelPath = tissueModelPath;
+            this.cellModelPath = null;
+
+        } else if (modelType == ModelType.MULTI) {
+            if (cellModelPath == null || tissueModelPath == null) {
+                throw new IllegalArgumentException("MULTI 모델은 cellModelPath와 tissueModelPath 모두 필요합니다.");
+            }
+            this.cellModelPath = cellModelPath;
+            this.tissueModelPath = tissueModelPath;
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 ModelType입니다: " + modelType);
+        }
     }
 }

--- a/backend/src/main/java/site/pathos/domain/model/entity/ProjectModel.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/ProjectModel.java
@@ -11,7 +11,10 @@ import site.pathos.domain.project.entity.Project;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "project_model")
+@Table(
+        name = "project_model",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"project_id", "model_id"})
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectModel {
@@ -23,7 +26,7 @@ public class ProjectModel {
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "model_id", nullable = false)
     private Model model;
 
@@ -34,7 +37,8 @@ public class ProjectModel {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @Builder ProjectModel(Project project, Model model, boolean isInitial){
+    @Builder
+    public ProjectModel(Project project, Model model, boolean isInitial){
         this.project = project;
         this.model = model;
         this.isInitial = isInitial;

--- a/backend/src/main/java/site/pathos/domain/model/entity/ProjectModel.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/ProjectModel.java
@@ -1,0 +1,42 @@
+package site.pathos.domain.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import site.pathos.domain.project.entity.Project;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "project_model")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectModel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "model_id", nullable = false)
+    private Model model;
+
+    @Column(name = "is_initial", nullable = false)
+    private boolean isInitial;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder ProjectModel(Project project, Model model, boolean isInitial){
+        this.project = project;
+        this.model = model;
+        this.isInitial = isInitial;
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
+++ b/backend/src/main/java/site/pathos/domain/model/service/ModelService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
+import site.pathos.domain.inferenceHistory.entity.TrainingHistory;
 import site.pathos.domain.model.Repository.ModelRepository;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.model.entity.ModelType;
@@ -14,14 +15,16 @@ public class ModelService {
     private final ModelRepository modelRepository;
 
     @Transactional
-    public void saveModel(AnnotationHistory history, String modelName, ModelType modelType, String modelPath){
+    public Model saveModel(TrainingHistory trainingHistory, String modelName,
+                           ModelType modelType, String tissueModelPath, String cellModelPath){
         Model model = Model.builder()
-                .annotationHistory(history)
+                .trainingHistory(trainingHistory)
                 .name(modelName)
                 .modelType(modelType)
-                .modelPath(modelPath)
+                .tissueModelPath(tissueModelPath)
+                .cellModelPath(cellModelPath)
                 .build();
 
-        modelRepository.save(model);
+        return modelRepository.save(model);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import site.pathos.domain.modelServer.dto.request.TrainingRequestDto;
 import site.pathos.domain.modelServer.dto.request.TrainingResultRequestDto;
 import site.pathos.domain.modelServer.service.ModelServerService;
 
@@ -19,22 +20,24 @@ public class ModelServerController {
     private final ModelServerService modelServerService;
 
     @Operation(summary = "모델 학습 요청", description = "클라이언트가 모델 서버에 학습을 요청합니다.")
-    @PostMapping("/training/{annotationHistoryId}")
+    @PostMapping("/training/{projectId}")
     public ResponseEntity<Void> requestTraining(
-            @Parameter(description = "학습을 요청할 AnnotationHistory ID", required = true)
-            @PathVariable Long annotationHistoryId) {
-        modelServerService.requestTraining(annotationHistoryId);
+            @Parameter(description = "학습을 요청할 project ID", required = true)
+            @PathVariable Long projectId,
+            @RequestBody TrainingRequestDto trainingRequestDto)
+    {
+        modelServerService.requestTraining(projectId, trainingRequestDto);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/annotation-histories/{annotationHistoryId}/training/result")
-    @Operation(summary = "모델 학습 결과 수신", description = "모델 서버가 학습 결과를 서버에 전달합니다.")
-    public ResponseEntity<Void> responseTraining(
-            @Parameter(description = "어노테이션 히스토리 ID") @PathVariable Long annotationHistoryId,
-            @Parameter(description = "모델 학습 결과 데이터", required = true)
-            @RequestBody TrainingResultRequestDto resultRequestDto) {
-
-        modelServerService.resultTraining(annotationHistoryId, resultRequestDto);
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/annotation-histories/{annotationHistoryId}/training/result")
+//    @Operation(summary = "모델 학습 결과 수신", description = "모델 서버가 학습 결과를 서버에 전달합니다.")
+//    public ResponseEntity<Void> responseTraining(
+//            @Parameter(description = "어노테이션 히스토리 ID") @PathVariable Long annotationHistoryId,
+//            @Parameter(description = "모델 학습 결과 데이터", required = true)
+//            @RequestBody TrainingResultRequestDto resultRequestDto) {
+//
+//        modelServerService.resultTraining(annotationHistoryId, resultRequestDto);
+//        return ResponseEntity.ok().build();
+//    }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/controller/ModelServerController.java
@@ -30,14 +30,14 @@ public class ModelServerController {
         return ResponseEntity.ok().build();
     }
 
-//    @PostMapping("/annotation-histories/{annotationHistoryId}/training/result")
-//    @Operation(summary = "모델 학습 결과 수신", description = "모델 서버가 학습 결과를 서버에 전달합니다.")
-//    public ResponseEntity<Void> responseTraining(
-//            @Parameter(description = "어노테이션 히스토리 ID") @PathVariable Long annotationHistoryId,
-//            @Parameter(description = "모델 학습 결과 데이터", required = true)
-//            @RequestBody TrainingResultRequestDto resultRequestDto) {
-//
-//        modelServerService.resultTraining(annotationHistoryId, resultRequestDto);
-//        return ResponseEntity.ok().build();
-//    }
+    @PostMapping("/porjects/{projectId}/training/result")
+    @Operation(summary = "모델 학습 결과 수신", description = "모델 서버가 학습 결과를 서버에 전달합니다.")
+    public ResponseEntity<Void> responseTraining(
+            @Parameter(description = "어노테이션 히스토리 ID") @PathVariable Long projectId,
+            @Parameter(description = "모델 학습 결과 데이터", required = true)
+            @RequestBody TrainingResultRequestDto resultRequestDto) {
+
+        modelServerService.resultTraining(projectId, resultRequestDto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestDto.java
@@ -1,15 +1,6 @@
 package site.pathos.domain.modelServer.dto.request;
 
-import site.pathos.domain.roi.dto.request.RoiRequestPayload;
-
-import java.util.List;
-
 public record TrainingRequestDto(
-        Long sub_project_id,
-        Long annotation_history_id,
-        String type,
-        String model_name,
-        String model_path,
-        String svs_path,
-        List<RoiRequestPayload> roi
-) {}
+        String modelName
+) {
+}

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestMessageDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestMessageDto.java
@@ -1,45 +1,123 @@
 package site.pathos.domain.modelServer.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import site.pathos.domain.model.entity.ModelType;
+
 import java.util.List;
 
+@Schema(description = "Training/Inference 요청 메시지 DTO")
 public record TrainingRequestMessageDto(
+        @Schema(description = "학습 기록 ID", example = "1")
+        Long trainingHistoryId,
+
+        @Schema(description = "추론 기록 ID", example = "1")
+        Long inferenceHistoryId,
+
+        @Schema(description = "프로젝트 ID", example = "1")
         Long projectId,
+
+        @Schema(description = "요청 타입", example = "TRAINING_INFERENCE")
         String type,
+
+        @Schema(description = "모델 종류", example = "MULTI")
+        ModelType modelType,
+
+        @Schema(description = "모델 이름", example = "custom-model-v1")
         String modelName,
-        String modelPath,
+
+        @Schema(description = "모델 경로 (S3 등)", example = "s3://my-bucket/models/deep-lab-v1.pt")
+        String tissueModelPath,
+
+        @Schema(description = "모델 경로 (S3 등)", example = "s3://my-bucket/models/nulite-v1.pt")
+        String cellModelPath,
+
+        @Schema(description = "모델 라벨 정보 목록")
         List<LabelInfo> labels,
+
+        @Schema(description = "SubProject 정보 목록")
         List<SubProjectInfo> subProjects
 ) {
+    @Schema(description = "라벨 정보")
     public record LabelInfo(
+            @Schema(description = "클래스 인덱스", example = "0")
             int classIndex,
+
+            @Schema(description = "클래스 이름", example = "Cancer Cell")
             String name,
+
+            @Schema(description = "RGB 색상", example = "[255, 0, 0]")
             int[] color
     ) {}
 
+    @Schema(description = "SubProject 단위 정보")
     public record SubProjectInfo(
+            @Schema(description = "SubProject ID", example = "101")
             Long subProjectId,
+
+            @Schema(description = "AnnotationHistory ID", example = "1001")
             Long annotationHistoryId,
+
+            @Schema(description = "SVS 이미지 경로", example = "s3://my-bucket/sub-project/101/svs/original.svs")
             String svsPath,
+
+            @Schema(description = "ROI 리스트")
             List<Roi> roi
     ) {}
 
+    @Schema(description = "ROI 정보")
     public record Roi(
+            @Schema(description = "ROI 아이디", example = "1")
+            Long roiId,
+
+            @Schema(description = "표시 순서", example = "0")
             int displayOrder,
+
+            @Schema(description = "ROI 영역 정보")
             RoiDetail detail,
-            String tissue_path,
+
+            @Schema(description = "조직 이미지 경로 (merged)", example = "s3://my-bucket/sub-project/101/roi-1/merged.jpg")
+            String tissuePath,
+
+            @Schema(description = "셀 정보 목록")
             List<Cell> cells
     ) {}
 
+    @Schema(description = "ROI의 위치 정보")
     public record RoiDetail(
+            @Schema(description = "X 좌표", example = "0")
             int x,
+
+            @Schema(description = "Y 좌표", example = "0")
             int y,
+
+            @Schema(description = "너비", example = "500")
             int width,
+
+            @Schema(description = "높이", example = "500")
             int height
     ) {}
 
+    @Schema(description = "셀 정보")
     public record Cell(
+            @Schema(description = "클래스 인덱스", example = "0")
+            int classIndex,
+
+            @Schema(description = "세포 외곽을 구성하는 폴리곤 좌표")
+            PolygonDto polygon
+    ) {}
+
+    @Schema(description = "Polygon 좌표 정보 DTO")
+    public record PolygonDto(
+            @Schema(description = "꼭짓점 좌표 리스트", example = "[{\"x\":123,\"y\":456}, {\"x\":124,\"y\":457}]")
+            List<PointDto> points
+    ) {}
+
+    @Schema(description = "2D 평면의 좌표")
+    public record PointDto(
+            @Schema(description = "X 좌표", example = "123")
             int x,
-            int y,
-            int classIndex
+
+            @Schema(description = "Y 좌표", example = "456")
+            int y
     ) {}
 }

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestMessageDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingRequestMessageDto.java
@@ -1,0 +1,45 @@
+package site.pathos.domain.modelServer.dto.request;
+
+import java.util.List;
+
+public record TrainingRequestMessageDto(
+        Long projectId,
+        String type,
+        String modelName,
+        String modelPath,
+        List<LabelInfo> labels,
+        List<SubProjectInfo> subProjects
+) {
+    public record LabelInfo(
+            int classIndex,
+            String name,
+            int[] color
+    ) {}
+
+    public record SubProjectInfo(
+            Long subProjectId,
+            Long annotationHistoryId,
+            String svsPath,
+            List<Roi> roi
+    ) {}
+
+    public record Roi(
+            int displayOrder,
+            RoiDetail detail,
+            String tissue_path,
+            List<Cell> cells
+    ) {}
+
+    public record RoiDetail(
+            int x,
+            int y,
+            int width,
+            int height
+    ) {}
+
+    public record Cell(
+            int x,
+            int y,
+            int classIndex
+    ) {}
+}

--- a/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/dto/request/TrainingResultRequestDto.java
@@ -1,16 +1,134 @@
 package site.pathos.domain.modelServer.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import site.pathos.domain.roi.dto.request.RoiRequestPayload;
+import site.pathos.domain.model.entity.ModelType;
 
 import java.util.List;
 
+@Schema(description = "Training/Inference 요청 메시지 DTO")
 public record TrainingResultRequestDto(
+        @Schema(description = "학습 기록 ID", example = "1")
+        Long trainingHistoryId,
 
-        @Schema(description = "학습된 모델이 저장된 경로", example = "s3://{bucket-name}/trained/model_101.pt", required = true)
-        String model_path,
+        @Schema(description = "추론 기록 ID", example = "1")
+        Long inferenceHistoryId,
 
-        @Schema(description = "학습 결과 ROI 정보 리스트", required = true)
-        List<RoiRequestPayload> roi
+        @Schema(description = "요청 타입", example = "TRAINING_INFERENCE")
+        String type,
 
-) { }
+        @Schema(description = "모델 종류", example = "MULTI")
+        ModelType modelType,
+
+        @Schema(description = "모델 이름", example = "custom-model-v1")
+        String modelName,
+
+        @Schema(description = "생성된 티슈 모델 경로", example = "s3://my-bucket/models/deep-lab-v1.pt")
+        String tissueModelPath,
+
+        @Schema(description = "생성된 셀 모델 경로", example = "s3://my-bucket/models/nulite-v1.pt")
+        String cellModelPath,
+
+        @Schema(description = "모델 라벨 정보 목록")
+        List<LabelInfo> labels,
+
+        @Schema(description = "SubProject 정보 목록")
+        List<SubProjectInfo> subProjects,
+
+        @Schema(description = "모델 성능 지표")
+        Performance performance
+) {
+        @Schema(description = "라벨 정보")
+        public record LabelInfo(
+                @Schema(description = "클래스 인덱스", example = "0")
+                int classIndex,
+
+                @Schema(description = "클래스 이름", example = "Cancer Cell")
+                String name,
+
+                @Schema(description = "RGB 색상", example = "[255, 0, 0]")
+                int[] color
+        ) {}
+
+        @Schema(description = "SubProject 단위 정보")
+        public record SubProjectInfo(
+                @Schema(description = "SubProject ID", example = "101")
+                Long subProjectId,
+
+                @Schema(description = "AnnotationHistory ID", example = "1001")
+                Long annotationHistoryId,
+
+                @Schema(description = "ROI 리스트")
+                List<Roi> roi
+        ) {}
+
+        @Schema(description = "ROI 정보")
+        public record Roi(
+                @Schema(description = "ROI 아이디", example = "1")
+                Long roiId,
+
+                @Schema(description = "표시 순서", example = "0")
+                int displayOrder,
+
+                @Schema(description = "ROI 영역 정보")
+                RoiDetail detail,
+
+                @Schema(description = "ROI faulty 백분율")
+                int faulty,
+
+                @Schema(description = "조직 이미지 경로 (merged)", example = "s3://my-bucket/sub-project/101/roi-1/merged.jpg")
+                String tissue_path,
+
+                @Schema(description = "셀 정보 목록")
+                List<Cell> cells
+        ) {}
+
+        @Schema(description = "ROI의 위치 정보")
+        public record RoiDetail(
+                @Schema(description = "X 좌표", example = "0")
+                int x,
+
+                @Schema(description = "Y 좌표", example = "0")
+                int y,
+
+                @Schema(description = "너비", example = "500")
+                int width,
+
+                @Schema(description = "높이", example = "500")
+                int height
+        ) {}
+
+        @Schema(description = "셀 정보")
+        public record Cell(
+                @Schema(description = "클래스 인덱스", example = "0")
+                int classIndex,
+
+                @Schema(description = "세포 외곽을 구성하는 폴리곤 좌표")
+                PolygonDto polygon
+        ) {}
+
+        @Schema(description = "Polygon 좌표 정보 DTO")
+        public record PolygonDto(
+                @Schema(description = "꼭짓점 좌표 리스트", example = "[{\"x\":123,\"y\":456}, {\"x\":124,\"y\":457}]")
+                List<PointDto> points
+        ) {}
+
+        @Schema(description = "2D 평면의 좌표")
+        public record PointDto(
+                @Schema(description = "X 좌표", example = "123")
+                int x,
+
+                @Schema(description = "Y 좌표", example = "456")
+                int y
+        ) {}
+
+        public record Performance(
+                @Schema(description = "정확도", example = "0.95")
+                float accuracy,
+
+                @Schema(description = "손실값", example = "0.23")
+                float loss,
+
+                @Schema(description = "반복 성능 점수", example = "0.88")
+                float loopPerformance
+        ) {}
+}

--- a/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/modelServer/service/ModelServerService.java
@@ -3,107 +3,201 @@ package site.pathos.domain.modelServer.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.pathos.domain.annotation.cellAnnotation.dto.CellDetail;
+import site.pathos.domain.annotation.cellAnnotation.entity.CellAnnotation;
+import site.pathos.domain.annotation.cellAnnotation.repository.CellAnnotationRepository;
 import site.pathos.domain.annotation.tissueAnnotation.entity.AnnotationType;
 import site.pathos.domain.annotation.tissueAnnotation.entity.TissueAnnotation;
 import site.pathos.domain.annotation.tissueAnnotation.repository.TissueAnnotationRepository;
+import site.pathos.domain.annotation.tissueAnnotation.service.TissueAnnotationService;
 import site.pathos.domain.annotationHistory.entity.AnnotationHistory;
 import site.pathos.domain.annotationHistory.repository.AnnotationHistoryRepository;
 import site.pathos.domain.inferenceHistory.service.InferenceHistoryService;
+import site.pathos.domain.label.entity.ModelProjectLabel;
+import site.pathos.domain.label.repository.ModelProjectLabelRepository;
+import site.pathos.domain.label.repository.ProjectLabelRepository;
 import site.pathos.domain.model.Repository.ModelRepository;
+import site.pathos.domain.model.Repository.ProjectModelRepository;
 import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.model.entity.ProjectModel;
 import site.pathos.domain.model.service.ModelService;
-import site.pathos.domain.modelServer.dto.request.TrainingResultRequestDto;
-import site.pathos.domain.modelServer.entity.ModelRequestType;
-import site.pathos.domain.roi.dto.request.RoiRequestPayload;
-import site.pathos.domain.roi.dto.request.RoiRequestDto;
-import site.pathos.domain.roi.entity.Roi;
 import site.pathos.domain.modelServer.dto.request.TrainingRequestDto;
+import site.pathos.domain.modelServer.dto.request.TrainingResultRequestDto;
+import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.project.repository.ProjectRepository;
+import site.pathos.domain.roi.entity.Roi;
+import site.pathos.domain.modelServer.dto.request.TrainingRequestMessageDto;
+import site.pathos.domain.roi.repository.RoiRepository;
 import site.pathos.domain.roi.service.RoiService;
+import site.pathos.domain.subProject.entity.SubProject;
+import site.pathos.domain.subProject.repository.SubProjectRepository;
 import site.pathos.global.aws.sqs.service.SqsService;
+import site.pathos.global.error.BusinessException;
+import site.pathos.global.error.ErrorCode;
+import site.pathos.global.util.color.ColorUtils;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ModelServerService {
     private final AnnotationHistoryRepository annotationHistoryRepository;
     private final TissueAnnotationRepository tissueAnnotationRepository;
+    private final CellAnnotationRepository cellAnnotationRepository;
 
     private final ModelService modelService;
     private final SqsService sqsService;
     private final InferenceHistoryService inferenceHistoryService;
     private final RoiService roiService;
     private final ModelRepository modelRepository;
+    private final TissueAnnotationService tissueAnnotationService;
+    private final ProjectRepository projectRepository;
+    private final SubProjectRepository subProjectRepository;
+    private final ProjectLabelRepository projectLabelRepository;
+    private final ProjectModelRepository projectModelRepository;
+    private final ModelProjectLabelRepository modelProjectLabelRepository;
+    private final RoiRepository roiRepository;
 
     @Transactional
-    public void requestTraining(Long annotationHistoryId) {
-        AnnotationHistory history = annotationHistoryRepository
-                .findWithSubProjectAndModelById(annotationHistoryId)
-                .orElseThrow(() -> new RuntimeException("not found"));
+    public void requestTraining(Long projectId, TrainingRequestDto trainingRequestDto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
-        TrainingRequestDto message = buildTrainingRequest(history);
+        TrainingRequestMessageDto message = buildTrainingRequest(project, trainingRequestDto.modelName());
 
         sqsService.sendTrainingRequest(message);
-        inferenceHistoryService.saveInferenceHistory(history);
+//        inferenceHistoryService.saveInferenceHistory();
     }
 
-    private TrainingRequestDto buildTrainingRequest(AnnotationHistory history) {
-        List<TissueAnnotation> mergedAnnotations = tissueAnnotationRepository.findMergedByAnnotationHistoryId(
-                history.getId(), AnnotationType.MERGED
-        );
+    private TrainingRequestMessageDto buildTrainingRequest(Project project, String modelName) {
+        ProjectModel projectModel = projectModelRepository.findLatestByProjectIdWithModel(project.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MODEL_NOT_FOUND));
 
-        List<RoiRequestPayload> roiMessages = mergedAnnotations.stream().map(ta -> {
-            Roi roi = ta.getRoi();
-            RoiRequestDto detail = new RoiRequestDto(roi.getX(), roi.getY(), roi.getWidth(), roi.getHeight());
+        //프로젝트에서 사용된 라벨의 정보 불러오기
+        List<TrainingRequestMessageDto.LabelInfo> labelInfos = getLabelInfos(projectModel.getModel().getId(), project.getId());
+        //프로젝트의 속한 서브프로젝트들의 하위 정보
+        List<TrainingRequestMessageDto.SubProjectInfo> subProjectInfos = getSubProjectInfos(project);
 
-            // TODO: cell 관련 로직 추가 필요
-            List<CellDetail> cellAnnotations = List.of();
-
-            List<String> imagePaths = List.of(ta.getAnnotationImageUrl());
-
-            return new RoiRequestPayload(roi.getDisplayOrder(), detail, imagePaths, cellAnnotations);
-        }).toList();
-
-        return new TrainingRequestDto(
-                history.getSubProject().getId(),
-                history.getId(),
-                ModelRequestType.TRAINING_INFERENCE.name(),
-                history.getModelName(),
-                history.getModel().getModelPath(),
-                history.getSubProject().getSvsImageUrl(),
-                roiMessages
+        return new TrainingRequestMessageDto(
+                project.getId(),
+                "TRAINING_INFERENCE",
+                modelName,
+                projectModel.getModel().getModelPath(),
+                labelInfos,
+                subProjectInfos
         );
     }
 
-    @Transactional
-    public void resultTraining(Long annotationHistoryId,TrainingResultRequestDto resultRequestDto){
-        AnnotationHistory history = annotationHistoryRepository
-                .findWithSubProjectAndModelById(annotationHistoryId)
-                .orElseThrow(() -> new RuntimeException("history not found"));
+    private List<TrainingRequestMessageDto.LabelInfo> getLabelInfos(Long modelId, Long projectId) {
+        List<ModelProjectLabel> modelProjectLabels = modelProjectLabelRepository
+                .findByModelIdAndProjectId(modelId, projectId);
 
-        AnnotationHistory newHistory = AnnotationHistory.builder()
-                .subProject(history.getSubProject())
-                .model(history.getModel())
-                .modelName(history.getModelName())
-                .build();
-
-        annotationHistoryRepository.save(newHistory);
-
-        Model baseModel = modelRepository.findByAnnotationHistoryId(history.getId())
-                .orElseThrow(() -> new RuntimeException("base model not found"));
-
-        //기존 history 기반으로 model 정보 생성, 어느 history 를 통해 생성된 모델인지
-        modelService.saveModel(history, history.getModelName(), baseModel.getModelType() ,resultRequestDto.model_path());
-
-        //TODO 모델서버에서 기능 추가시 수정 필요
-        inferenceHistoryService.updateInferenceHistory(annotationHistoryId,
-                0,
-                0,
-                0
-                );
-
-        //새로운 annotation_history 에 roi 새로 저장
-        roiService.saveResultRois(newHistory, resultRequestDto.roi());
+        return modelProjectLabels.stream()
+                .map(ml -> new TrainingRequestMessageDto.LabelInfo(
+                        ml.getClassIndex(),
+                        ml.getProjectLabel().getName(),
+                        ColorUtils.hexToRgb(ml.getProjectLabel().getColor())
+                ))
+                .toList();
     }
+
+    private List<TrainingRequestMessageDto.SubProjectInfo> getSubProjectInfos(Project project) {
+        List<SubProject> subProjects = subProjectRepository.findAllByProjectId(project.getId());
+
+        return subProjects.stream()
+                .map(subProject -> {
+                    AnnotationHistory latestHistory = annotationHistoryRepository
+                            .findLatestBySubProjectId(subProject.getId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.ANNOTATION_HISTORY_NOT_FOUND));
+
+                    List<Roi> rois = roiRepository.findAllByAnnotationHistoryId(latestHistory.getId());
+                    List<Long> roiIds = rois.stream().map(Roi::getId).toList();
+
+                    List<CellAnnotation> cellAnnotations = cellAnnotationRepository.findAllByRoiIdIn(roiIds);
+                    List<TissueAnnotation> tissueAnnotations =
+                            tissueAnnotationRepository.findByRoiIdInAndAnnotationType(roiIds, AnnotationType.MERGED);
+
+                    Map<Long, List<CellAnnotation>> roiToCells = cellAnnotations.stream()
+                            .collect(Collectors.groupingBy(c -> c.getRoi().getId()));
+
+                    Map<Long, List<TissueAnnotation>> roiToTissues = tissueAnnotations.stream()
+                            .collect(Collectors.groupingBy(t -> t.getRoi().getId()));
+
+                    List<TrainingRequestMessageDto.Roi> roiDtos = rois.stream()
+                            .map(r -> mapToRoiDto(r, roiToCells, roiToTissues))
+                            .toList();
+
+                    return new TrainingRequestMessageDto.SubProjectInfo(
+                            subProject.getId(),
+                            latestHistory.getId(),
+                            subProject.getSvsImageUrl(),
+                            roiDtos
+                    );
+                })
+                .toList();
+    }
+
+    private TrainingRequestMessageDto.Roi mapToRoiDto(
+            Roi r,
+            Map<Long, List<CellAnnotation>> roiToCells,
+            Map<Long, List<TissueAnnotation>> roiToTissues
+    ) {
+        List<TrainingRequestMessageDto.Cell> cells = roiToCells.getOrDefault(r.getId(), List.of())
+                .stream()
+                .map(c -> new TrainingRequestMessageDto.Cell(
+                        c.getX(),
+                        c.getY(),
+                        c.getClassIndex()
+                ))
+                .toList();
+
+        String tissuePath = roiToTissues.getOrDefault(r.getId(), List.of())
+                .stream()
+                .filter(t -> t.getAnnotationType() == AnnotationType.MERGED)
+                .map(TissueAnnotation::getAnnotationImageUrl)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.MERGED_TISSUE_NOT_FOUND));
+
+        return new TrainingRequestMessageDto.Roi(
+                r.getDisplayOrder(),
+                new TrainingRequestMessageDto.RoiDetail(
+                        r.getX(), r.getY(), r.getWidth(), r.getHeight()
+                ),
+                tissuePath,
+                cells
+        );
+    }
+
+//    @Transactional
+//    public void resultTraining(Long annotationHistoryId,TrainingResultRequestDto resultRequestDto){
+//        AnnotationHistory history = annotationHistoryRepository
+//                .findWithSubProjectAndModelById(annotationHistoryId)
+//                .orElseThrow(() -> new RuntimeException("history not found"));
+//
+//        AnnotationHistory newHistory = AnnotationHistory.builder()
+//                .subProject(history.getSubProject())
+//                .model(history.getModel())
+//                .modelName(history.getModelName())
+//                .build();
+//
+//        annotationHistoryRepository.save(newHistory);
+//
+//        Model baseModel = modelRepository.findByAnnotationHistoryId(history.getId())
+//                .orElseThrow(() -> new RuntimeException("base model not found"));
+//
+//        //기존 history 기반으로 model 정보 생성, 어느 history 를 통해 생성된 모델인지
+//        modelService.saveModel(history, history.getModelName(), baseModel.getModelType() ,resultRequestDto.model_path());
+//
+//        //TODO 모델서버에서 기능 추가시 수정 필요
+//        inferenceHistoryService.updateInferenceHistory(annotationHistoryId,
+//                0,
+//                0,
+//                0
+//                );
+//
+//        //새로운 annotation_history 에 roi 새로 저장
+//        roiService.saveResultRois(newHistory, resultRequestDto.roi());
+//    }
+
 }

--- a/backend/src/main/java/site/pathos/domain/project/dto/response/GetProjectsResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/project/dto/response/GetProjectsResponseDto.java
@@ -14,6 +14,8 @@ public record GetProjectsResponseDto(
             Long projectId,
             @Schema(description = "프로젝트명", example = "Upsilon Viz")
             String title,
+            @Schema(description = "프로젝트 설명", example = "Initial tissue analysis project")
+            String description,
             @Schema(description = "프로젝트 생성일", example = "2025. 03. 20 (Thu)")
             String createdAt,
             @Schema(description = "프로젝트 수정일", example = "2025. 03. 21 (Fri)")

--- a/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
@@ -20,4 +20,13 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
         WHERE p.id IN :ids
     """)
     List<Project> fetchProjectsWithSubProjectsByIds(@Param("ids") List<Long> ids);
+
+    @Query("""
+    SELECT p FROM Project p
+    JOIN FETCH p.user
+    WHERE p.id = (
+        SELECT sp.project.id FROM SubProject sp WHERE sp.id = :subProjectId
+    )
+""")
+    Project findProjectWithUserBySubProjectId(@Param("subProjectId") Long subProjectId);
 }

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -20,6 +20,7 @@ import site.pathos.domain.label.repository.ProjectLabelRepository;
 import site.pathos.domain.model.Repository.ModelRepository;
 import site.pathos.domain.model.Repository.ProjectModelRepository;
 import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.model.entity.ProjectModel;
 import site.pathos.domain.project.dto.request.CreateProjectRequestDto;
 import site.pathos.domain.project.dto.request.UpdateProjectRequestDto;
 import site.pathos.domain.project.dto.response.GetProjectDetailResponseDto;
@@ -239,7 +240,7 @@ public class ProjectService {
         Project project = getProject(projectId, userId);
 
         List<SubProject> subProjects = getSubProjects(project);
-        Model recentModel = getRecentModel(subProjects);
+        Model recentModel = getRecentModel(project);
         String createdAt = DateTimeUtils.dateTimeToStringFormat(project.getCreatedAt());
         String updatedAt = DateTimeUtils.dateTimeToStringFormat(project.getUpdatedAt());
         SlideSummaryDto slideSummaryDto = getSlideSummaryDto(subProjects);
@@ -252,7 +253,7 @@ public class ProjectService {
                 projectId,
                 project.getTitle(),
                 project.getDescription(),
-                recentModel.getModelType(),
+                project.getModelType(),
                 recentModel.getName(),
                 createdAt,
                 updatedAt,
@@ -286,11 +287,10 @@ public class ProjectService {
         return subProjects;
     }
 
-    private Model getRecentModel(List<SubProject> subProjects) {
-        SubProject recentSubProject = subProjects.get(subProjects.size() - 1);
-        AnnotationHistory recentAnnotationHistory = recentSubProject.getAnnotationHistories()
-                .get(recentSubProject.getAnnotationHistories().size() - 1);
-        return recentAnnotationHistory.getModel();
+    private Model getRecentModel(Project project) {
+        return projectModelRepository.findLatestByProjectIdWithModel(project.getId())
+                .map(ProjectModel::getModel)
+                .orElse(null); // 혹은 orElseThrow(...)로 바꿔도 됨
     }
 
     private List<LabelDto> getLabelDtos(Long projectId) {

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -192,6 +192,7 @@ public class ProjectService {
             projectDetails.add(new GetProjectsResponseDto.GetProjectsResponseDetailDto(
                     project.getId(),
                     project.getTitle(),
+                    project.getDescription(),
                     DateTimeUtils.dateTimeToStringFormat(project.getCreatedAt()),
                     DateTimeUtils.dateTimeToStringFormat(project.getUpdatedAt()),
                     project.getModelType(),

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -104,9 +104,9 @@ public class ProjectService {
                     .project(project)
                     .build();
             subProjectRepository.save(subProject);
-            String svsKey = subProject.initializeSvsImageUrl();
-            subProject.initializeThumbnailImageUrl();
-            subProject.initializeTileImageUrl();
+            String svsKey = subProject.initializeSvsImagePath();
+            subProject.initializeThumbnailImagePath();
+            subProject.initializeTileImagePath();
             uploadFiles.add(new S3UploadFileDto(subProject.getId(), svsKey, file));
 
             AnnotationHistory annotationHistory = AnnotationHistory.builder()
@@ -182,7 +182,7 @@ public class ProjectService {
                     .orElse("");
 
             List<String> thumbnailUrls = subProjects.stream()
-                    .map(SubProject::getThumbnailUrl)
+                    .map(SubProject::getThumbnailPath)
                     .filter(url -> url != null && !url.isBlank())
                     .limit(4)
                     .toList();
@@ -340,7 +340,7 @@ public class ProjectService {
         return subProjects.stream()
                 .map(subProject -> new SlideDto(
                         subProject.getId(),
-                        Objects.requireNonNullElse(subProject.getThumbnailUrl(), ""),
+                        Objects.requireNonNullElse(subProject.getThumbnailPath(), ""),
                         subProject.getFileName(),
                         "", // TODO 파일 사이즈
                         DateTimeUtils.dateTimeToDateFormat(subProject.getCreatedAt())  // TODO 파일 업로드 시간

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -184,6 +184,7 @@ public class ProjectService {
             List<String> thumbnailUrls = subProjects.stream()
                     .map(SubProject::getThumbnailPath)
                     .filter(url -> url != null && !url.isBlank())
+                    .map(s3Service::getPresignedUrl)
                     .limit(4)
                     .toList();
 

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -112,7 +112,6 @@ public class ProjectService {
             AnnotationHistory annotationHistory = AnnotationHistory.builder()
                     .subProject(subProject)
                     .model(model)
-                    .modelName(model.getName())
                     .build();
             annotationHistoryRepository.save(annotationHistory);
         }

--- a/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/request/RoiRequestPayload.java
@@ -17,6 +17,6 @@ public record RoiRequestPayload(
         List<String> tissue_path,
 
         @Schema(description = "세포 좌표 리스트")
-        List<CellDetail> cell
+        List<CellDetail> cells
 
 ) {}

--- a/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/roi/dto/response/RoiResponseDto.java
@@ -18,6 +18,6 @@ public record RoiResponseDto(
         @Schema(description = "ROI의 높이", example = "512")
         int height,
 
-        @Schema(description = "ROI의 결함 비율 (0.0 ~ 1.0)", example = "0.15")
-        Double faulty
+        @Schema(description = "ROI의 결함 백분율 19", example = "19")
+        int faulty
 ) {}

--- a/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
+++ b/backend/src/main/java/site/pathos/domain/roi/entity/Roi.java
@@ -41,13 +41,14 @@ public class Roi {
     private int height;
 
     @Column(name = "faulty")
-    private Double faulty;
+    private int faulty;
 
     @Column(name = "display_order", nullable = false)
     private int displayOrder;
 
     @Builder
-    public Roi(AnnotationHistory annotationHistory, int x, int y, int width, int height, int displayOrder) {
+    public Roi(AnnotationHistory annotationHistory, int x, int y, int width, int height
+            , int displayOrder, int faulty) {
         if (annotationHistory == null) throw new IllegalArgumentException("annotationHistory cannot be null");
 
         this.annotationHistory = annotationHistory;
@@ -56,6 +57,7 @@ public class Roi {
         this.width = width;
         this.height = height;
         this.displayOrder = displayOrder;
+        this.faulty = faulty;
     }
 
     public void changeCoordinates(int x, int y, int width, int height) {

--- a/backend/src/main/java/site/pathos/domain/sharedProject/entity/SharedProject.java
+++ b/backend/src/main/java/site/pathos/domain/sharedProject/entity/SharedProject.java
@@ -27,8 +27,8 @@ public class SharedProject {
     @Column(name = "description")
     private String description;
 
-    @Column(name = "thumbnail_image_url", nullable = false)
-    private String thumbnailImageUrl;
+    @Column(name = "thumbnail_image_path", nullable = false)
+    private String thumbnailImagePath;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -41,14 +41,14 @@ public class SubProject {
     @OneToMany(mappedBy = "subProject", fetch = FetchType.LAZY)
     private List<AnnotationHistory> annotationHistories = new ArrayList<>();
 
-    @Column(name = "svs_image_url")
-    private String svsImageUrl;
+    @Column(name = "svs_image_path")
+    private String svsImagePath;
 
-    @Column(name = "tile_image_url")
-    private String tileImageUrl;
+    @Column(name = "tile_image_path")
+    private String tileImagePath;
 
-    @Column(name = "thumbnail_url")
-    private String thumbnailUrl;
+    @Column(name = "thumbnail_path")
+    private String thumbnailPath;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -72,29 +72,29 @@ public class SubProject {
         this.isUploadComplete = false;
     }
 
-    public String initializeSvsImageUrl() {
+    public String initializeSvsImagePath() {
         if (this.id == null) {
             throw new IllegalStateException("SubProject ID must be set before initializing svsImageUrl.");
         }
-        return this.svsImageUrl = String.format("sub-project/%s/svs/original.svs", this.id);
+        return this.svsImagePath = String.format("sub-project/%s/svs/original.svs", this.id);
     }
 
     public String getFileName() {
-        return Paths.get(svsImageUrl).getFileName().toString();
+        return Paths.get(svsImagePath).getFileName().toString();
     }
 
-    public String initializeThumbnailImageUrl() {
+    public String initializeThumbnailImagePath() {
         if (this.id == null) {
             throw new IllegalStateException("SubProject ID must be set before initializing thumbnailImageUrl.");
         }
-        return this.thumbnailUrl = String.format("sub-project/%s/thumbnail/thumbnail.jpg", this.id);
+        return this.thumbnailPath = String.format("sub-project/%s/thumbnail/thumbnail.jpg", this.id);
     }
 
-    public String initializeTileImageUrl() {
+    public String initializeTileImagePath() {
         if (this.id == null) {
             throw new IllegalStateException("SubProject ID must be set before initializing tileImageUrl.");
         }
-        return this.tileImageUrl = String.format("sub-project/%s/tiles/output_slide.dzi", this.id);
+        return this.tileImagePath = String.format("sub-project/%s/tiles/output_slide.dzi", this.id);
 
     }
 

--- a/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
@@ -29,4 +29,6 @@ public interface SubProjectRepository extends JpaRepository<SubProject, Long> {
     List<SubProject> findSubProjectsByProject(Project project);
 
     boolean existsByProjectIdAndIsUploadCompleteFalse(Long projectId);
+
+    List<SubProject> findAllByProjectId(Long projectId);
 }

--- a/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
@@ -9,8 +9,9 @@ import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
 import site.pathos.domain.subProject.entity.SubProject;
 
 public interface SubProjectRepository extends JpaRepository<SubProject, Long> {
-    @Query("SELECT new site.pathos.domain.subProject.dto.response.SubProjectSummaryDto(sp.id, sp.thumbnailUrl, sp.isUploadComplete) " +
-            "FROM SubProject sp WHERE sp.project.id = :projectId")
+    @Query("SELECT new site.pathos.domain.subProject.dto.response.SubProjectSummaryDto(sp.id, sp.thumbnailPath, sp.isUploadComplete) " +
+            "FROM SubProject sp " +
+            "WHERE sp.project.id = :projectId")
     List<SubProjectSummaryDto> findSubProjectIdAndThumbnailByProjectId(@Param("projectId") Long projectId);
 
     @Query("""

--- a/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/repository/SubProjectRepository.java
@@ -9,9 +9,6 @@ import site.pathos.domain.subProject.dto.response.SubProjectSummaryDto;
 import site.pathos.domain.subProject.entity.SubProject;
 
 public interface SubProjectRepository extends JpaRepository<SubProject, Long> {
-    @Query("SELECT s.project FROM SubProject s WHERE s.id = :subProjectId")
-    Project findProjectBySubProjectId(@Param("subProjectId") Long subProjectId);
-
     @Query("SELECT new site.pathos.domain.subProject.dto.response.SubProjectSummaryDto(sp.id, sp.thumbnailUrl, sp.isUploadComplete) " +
             "FROM SubProject sp WHERE sp.project.id = :projectId")
     List<SubProjectSummaryDto> findSubProjectIdAndThumbnailByProjectId(@Param("projectId") Long projectId);

--- a/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/service/SubProjectService.java
@@ -41,7 +41,7 @@ public class SubProjectService {
         List<AnnotationHistory> histories = annotationHistoryRepository
                 .findAllBySubProjectId(subProjectId)
                 .stream()
-                .sorted(Comparator.comparing(AnnotationHistory::getStartedAt)) // startedAt 기준 정렬
+                .sorted(Comparator.comparing(AnnotationHistory::getCreatedAt)) // startedAt 기준 정렬
                 .toList();
 
         List<AnnotationHistorySummaryDto> historyDtos = IntStream.range(0, histories.size())
@@ -50,7 +50,7 @@ public class SubProjectService {
                     return new AnnotationHistorySummaryDto(
                             h.getId(),
                             i+1,
-                            h.getStartedAt(),
+                            h.getCreatedAt(),
                             h.getCompletedAt()// 1번부터 시작
                     );
                 })

--- a/backend/src/main/java/site/pathos/domain/user/entity/User.java
+++ b/backend/src/main/java/site/pathos/domain/user/entity/User.java
@@ -20,6 +20,6 @@ public class User {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "profile_image_url", nullable = false)
-    private String profileImageUrl;
+    @Column(name = "profile_image_path", nullable = false)
+    private String profileImagePath;
 }

--- a/backend/src/main/java/site/pathos/domain/userModel/repository/UserModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/userModel/repository/UserModelRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 
 @Repository
 public interface UserModelRepository extends JpaRepository<UserModel, Long> {
-    @Query("SELECT m FROM UserModel u JOIN u.model m WHERE u.id = :userId")
+    @Query("SELECT m FROM UserModel u JOIN u.model m WHERE u.user.id = :userId")
     List<Model> findAllModelsByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/site/pathos/global/aws/s3/S3Service.java
+++ b/backend/src/main/java/site/pathos/global/aws/s3/S3Service.java
@@ -25,15 +25,7 @@ import site.pathos.global.aws.s3.dto.S3UploadFileDto;
 import site.pathos.global.util.image.ImageUtils;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
-import software.amazon.awssdk.services.s3.model.CompletedPart;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.UploadPartRequest;
-import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -169,6 +161,13 @@ public class S3Service {
                     log.error("일부 파일 업로드 실패", ex);
                     return null;
                 });
+    }
+
+    public void deleteFile(String key) {
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(awsProperty.s3().bucket())
+                .key(key)
+                .build());
     }
 
     public void uploadFileAsMultipart(String key, MultipartFile file) {

--- a/backend/src/main/java/site/pathos/global/aws/sqs/service/SqsService.java
+++ b/backend/src/main/java/site/pathos/global/aws/sqs/service/SqsService.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j; // Log4j 대신 Slf4j로 변경 (Spring Boot에서 선호)
 import org.springframework.stereotype.Service;
 import site.pathos.global.aws.config.AwsProperty;
-import site.pathos.domain.modelServer.dto.request.TrainingRequestDto;
+import site.pathos.domain.modelServer.dto.request.TrainingRequestMessageDto;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
@@ -19,7 +19,7 @@ public class SqsService {
     private final AwsProperty awsProperty;
     private final ObjectMapper objectMapper;
 
-    public void sendTrainingRequest(TrainingRequestDto message) {
+    public void sendTrainingRequest(TrainingRequestMessageDto message) {
         try {
             String messageBody = objectMapper.writeValueAsString(message);
             sendMessage(messageBody);

--- a/backend/src/main/java/site/pathos/global/config/AsyncConfig.java
+++ b/backend/src/main/java/site/pathos/global/config/AsyncConfig.java
@@ -20,4 +20,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "trainingExecutor")
+    public Executor trainingExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("training-async-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/backend/src/main/java/site/pathos/global/error/ErrorCode.java
+++ b/backend/src/main/java/site/pathos/global/error/ErrorCode.java
@@ -12,10 +12,11 @@ public enum ErrorCode {
     MODEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모델을 찾을 수 없습니다."),
     SUB_PROJECT_NOT_READY(HttpStatus.BAD_REQUEST, "아직 모든 서브프로젝트의 이미지 업로드가 완료되지 않았습니다."),
     SUB_PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 서브프로젝트를 찾을 수 없습니다."),
-    HEX_COLOR_INVALID(HttpStatus.BAD_REQUEST, "색상정보가 올바른 형식이 아닙니다. 않습니다"),
+    HEX_COLOR_INVALID(HttpStatus.BAD_REQUEST, "색상정보가 올바른 형식이 아닙니다."),
     ANNOTATION_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 서브 프로젝트에서 어노테이션 히스토리를 찾을수 없습니다."),
     MERGED_TISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ROI에서 TISSUE 어노테이션의 파일을 찾을 수 없습니다."),
-
+    TRAINING_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 학습 기록을 찾을 수 없습니다."),
+    INFERENCE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 추론 기록을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/site/pathos/global/error/ErrorCode.java
+++ b/backend/src/main/java/site/pathos/global/error/ErrorCode.java
@@ -10,8 +10,12 @@ public enum ErrorCode {
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로젝트를 찾을 수 없습니다."),
     NO_PROJECT_ACCESS(HttpStatus.FORBIDDEN, "프로젝트 접근 권한이 없습니다."),
     MODEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모델을 찾을 수 없습니다."),
-    SUB_PROJECT_NOT_READY(HttpStatus.BAD_REQUEST, "아직 모든 SubProject의 이미지 업로드가 완료되지 않았습니다."),
+    SUB_PROJECT_NOT_READY(HttpStatus.BAD_REQUEST, "아직 모든 서브프로젝트의 이미지 업로드가 완료되지 않았습니다."),
     SUB_PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 서브프로젝트를 찾을 수 없습니다."),
+    HEX_COLOR_INVALID(HttpStatus.BAD_REQUEST, "색상정보가 올바른 형식이 아닙니다. 않습니다"),
+    ANNOTATION_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 서브 프로젝트에서 어노테이션 히스토리를 찾을수 없습니다."),
+    MERGED_TISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 ROI에서 TISSUE 어노테이션의 파일을 찾을 수 없습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/site/pathos/global/error/ErrorCode.java
+++ b/backend/src/main/java/site/pathos/global/error/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     NO_PROJECT_ACCESS(HttpStatus.FORBIDDEN, "프로젝트 접근 권한이 없습니다."),
     MODEL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모델을 찾을 수 없습니다."),
     SUB_PROJECT_NOT_READY(HttpStatus.BAD_REQUEST, "아직 모든 SubProject의 이미지 업로드가 완료되지 않았습니다."),
+    SUB_PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 서브프로젝트를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/site/pathos/global/util/color/ColorUtils.java
+++ b/backend/src/main/java/site/pathos/global/util/color/ColorUtils.java
@@ -1,0 +1,21 @@
+package site.pathos.global.util.color;
+
+import site.pathos.global.error.BusinessException;
+import site.pathos.global.error.ErrorCode;
+
+public class ColorUtils {
+
+    public static int[] hexToRgb(String hex) {
+        if (hex == null || !hex.matches("^#?[0-9a-fA-F]{6}$")) {
+            throw new BusinessException(ErrorCode.HEX_COLOR_INVALID);
+        }
+
+        hex = hex.substring(1);
+
+        int r = Integer.parseInt(hex.substring(0, 2), 16);
+        int g = Integer.parseInt(hex.substring(2, 4), 16);
+        int b = Integer.parseInt(hex.substring(4, 6), 16);
+
+        return new int[] { r, g, b };
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #120 

## 📝작업 내용

이번 PR에서는 전체적인 어노테이션 및 학습 흐름을 SubProject 단위에서 Project 단위로 전환하고, 모델 관리 구조를 개선하며, 폴리곤 기반의 Cell 어노테이션, Presigned URL 처리 개선 등의 작업을 포함합니다. 대규모 리팩토링 및 구조 변경이 포함되어 있어 전체 백엔드 흐름에 영향을 줍니다.

1.  학습/추론 단위 Project 중심으로 변경
	•	기존의 SubProject 단위로 요청되던 학습 흐름을 Project 단위로 변경
	•	이를 통해 여러 SubProject를 통합해 학습할 수 있는 구조 도입
	•	TrainingHistory, InferenceHistory 도입 및 관리 방식 변경

2.  Model 관리 구조 확장 및 정비
	•	ProjectModel 테이블 추가: 프로젝트에서 사용 가능한 모델을 명시적으로 관리
	•	Model 엔티티 내에 cellModelPath, tissueModelPath 분리 저장 로직 추가 → MULTI 타입 지원 강화
	•	ModelType 별 path validation 적용 (CELL, TISSUE, MULTI)

3. CellAnnotation 폴리곤 구조로 변경
	•	기존 단일 (x, y, radius) 좌표에서 → Polygon(Point 리스트) 로 구조 변경
	•	프론트 및 모델 서버와의 호환을 위한 DTO 구조도 모두 변경

4.  Label 관리 구조 개선
	•	Label 을 Project와 Model 별로 각각 관리할 수 있도록 분리
	•	모델 학습 시점의 label 스냅샷 저장 및 재현 가능성 강화

5. 🧾 AnnotationHistory 구조 개편
	•	model_name 문자열 컬럼 제거
	•	Model 과 직접 연관 대신 TrainingHistory 연관을 통해 유연성 확보
	•	created_at, updated_at, completed_at 구분 정리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
