### PR TITLE
[BE] HOTFIX: formdata로 multipart와 json 업로드에 대한 설정 추가

### DIFF
--- a/backend/src/main/java/site/pathos/domain/project/controller/AnnotationController.java
+++ b/backend/src/main/java/site/pathos/domain/project/controller/AnnotationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import site.pathos.domain.project.service.AnnotationService;
 import site.pathos.domain.roi.dto.request.RoiLabelSaveRequestDto;
+import site.pathos.global.annotation.FormDataRequestBody;
 
 import java.util.List;
 
@@ -26,6 +27,7 @@ public class AnnotationController {
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
     )
     @Operation(summary = "ROI, 이미지, 라벨 업로드", description = "특정 SubProject와 AnnotationHistory에 ROI, 관련 이미지, 라벨 정보를 업로드합니다.")
+    @FormDataRequestBody
     public ResponseEntity<Void> uploadRois(
             @Parameter(description = "서브 프로젝트 ID", required = true)
             @PathVariable Long subProjectId,

--- a/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/site/pathos/domain/project/controller/ProjectController.java
@@ -25,6 +25,7 @@ import site.pathos.domain.project.dto.response.GetProjectsResponseDto;
 import site.pathos.domain.project.dto.response.GetSubProjectResponseDto;
 import site.pathos.domain.project.enums.ProjectSortType;
 import site.pathos.domain.project.service.ProjectService;
+import site.pathos.global.annotation.FormDataRequestBody;
 
 @Tag(name = "Project API", description = "프로젝트 기능 API")
 @RestController
@@ -50,6 +51,7 @@ public class ProjectController {
 
     @Operation(summary = "프로젝트를 생성합니다.")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @FormDataRequestBody
     public ResponseEntity<Void> createProject(
             @RequestPart CreateProjectRequestDto requestDto,
             @RequestPart List<MultipartFile> files

--- a/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
+++ b/backend/src/main/java/site/pathos/domain/subProject/entity/SubProject.java
@@ -54,6 +54,7 @@ public class SubProject {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @CreationTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/site/pathos/global/annotation/FormDataRequestBody.java
+++ b/backend/src/main/java/site/pathos/global/annotation/FormDataRequestBody.java
@@ -1,0 +1,22 @@
+package site.pathos.global.annotation;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestBody(
+        content = @Content(
+                encoding = @Encoding(
+                        name = "requestDto",
+                        contentType = MediaType.APPLICATION_JSON_VALUE
+                )
+        )
+)
+public @interface FormDataRequestBody {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- Closes #136 

## 📝작업 내용

@FormDataRequestBody라는 커스텀 어노테이션을 통해
FormData 형식으로 Multipart와 JSON을 업로드 받을 때
requestDto라는 이름의 key값을 JSON으로 매칭해줍니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
