### PR TITLE
[BE] fix/#147 이미지 슬라이싱 위치를 0,0 으로 수정

### DIFF
--- a/backend/src/main/java/site/pathos/domain/annotation/service/TissueAnnotationService.java
+++ b/backend/src/main/java/site/pathos/domain/annotation/service/TissueAnnotationService.java
@@ -100,8 +100,6 @@ public class TissueAnnotationService {
 
         List<ImageTile> tiles = ImageUtils.sliceImageByROIWithPosition(
                 resultImage,
-                roi.getX(),
-                roi.getY(),
                 roi.getWidth(),
                 roi.getHeight()
         );

--- a/backend/src/main/java/site/pathos/global/util/image/ImageUtils.java
+++ b/backend/src/main/java/site/pathos/global/util/image/ImageUtils.java
@@ -53,7 +53,7 @@ public class ImageUtils {
         else return 3 + (int) Math.ceil((dimension - 40000) / 10000.0);
     }
 
-    public static List<ImageTile> sliceImageByROIWithPosition(BufferedImage image, int roiX, int roiY, int roiWidth, int roiHeight) {
+    public static List<ImageTile> sliceImageByROIWithPosition(BufferedImage image, int roiWidth, int roiHeight) {
         List<ImageTile> tiles = new ArrayList<>();
 
         int cols = getDivisionCountDynamic(roiWidth);
@@ -65,11 +65,11 @@ public class ImageUtils {
         int widthRemainder = roiWidth % cols;
         int heightRemainder = roiHeight % rows;
 
-        int yOffset = roiY;
+        int yOffset = 0;
 
         for (int row = 0; row < rows; row++) {
             int tileHeight = baseTileHeight + (row < heightRemainder ? 1 : 0);
-            int xOffset = roiX;
+            int xOffset = 0;
 
             for (int col = 0; col < cols; col++) {
                 int tileWidth = baseTileWidth + (col < widthRemainder ? 1 : 0);


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #147 

## 📝작업 내용

모델 추론 결과물을 받아올 시 이미지를 슬라이싱 할 때 roi 시작 좌표가 아닌 0,0부터 잘라가도록 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
