### PR TITLE
[BE] fix: 로그인한 유저의 Id를 SecurityUtil에서 가져오도록 수정

### DIFF
--- a/backend/src/main/java/site/pathos/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/site/pathos/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
 
     public JwtTokenDto refreshTokens(String refreshToken) {
         if (!jwtProvider.validateToken(refreshToken)) {
-            throw new IllegalArgumentException("Invalid refresh token");
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         Long userId = jwtProvider.getUserIdFromToken(refreshToken);
@@ -33,7 +33,7 @@ public class AuthService {
 
         String saved = refreshTokenService.get(userId);
         if (saved == null || !saved.equals(refreshToken)) {
-            throw new IllegalArgumentException("Refresh token mismatch");
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         String newAccessToken = jwtProvider.createAccessToken(user);

--- a/backend/src/main/java/site/pathos/domain/model/repository/ModelRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/repository/ModelRepository.java
@@ -1,17 +1,52 @@
 package site.pathos.domain.model.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.model.enums.ModelType;
-
-import java.util.Optional;
+import site.pathos.domain.user.entity.User;
 
 @Repository
 public interface ModelRepository extends JpaRepository<Model, Long> {
-    Optional<Model> findFirstByTrainingHistoryIsNullAndModelTypeAndTissueModelPathIsNotNullAndCellModelPathIsNullOrderByTrainedAtDesc(ModelType modelType);
+    @Query("""
+    SELECT m FROM UserModel um
+    JOIN um.model m
+    WHERE um.user = :user
+      AND m.trainingHistory IS NULL
+      AND m.modelType = :modelType
+      AND m.tissueModelPath IS NOT NULL
+      AND m.cellModelPath IS NULL
+    ORDER BY m.trainedAt DESC
+    """)
+    Optional<Model> findFirstTissueModelByUser(@Param("modelType") ModelType modelType, @Param("user") User user);
 
-    Optional<Model> findFirstByTrainingHistoryIsNullAndModelTypeAndCellModelPathIsNotNullAndTissueModelPathIsNullOrderByTrainedAtDesc(ModelType modelType);
 
-    Optional<Model> findFirstByTrainingHistoryIsNullAndModelTypeAndCellModelPathIsNotNullAndTissueModelPathIsNotNullOrderByTrainedAtDesc(ModelType modelType);
+    @Query("""
+    SELECT m FROM UserModel um
+    JOIN um.model m
+    WHERE um.user = :user
+      AND m.trainingHistory IS NULL
+      AND m.modelType = :modelType
+      AND m.cellModelPath IS NOT NULL
+      AND m.tissueModelPath IS NULL
+    ORDER BY m.trainedAt DESC
+    """)
+    Optional<Model> findFirstCellModelByUser(@Param("modelType") ModelType modelType, @Param("user") User user);
+
+
+    @Query("""
+    SELECT m FROM UserModel um
+    JOIN um.model m
+    WHERE um.user = :user
+      AND m.trainingHistory IS NULL
+      AND m.modelType = :modelType
+      AND m.cellModelPath IS NOT NULL
+      AND m.tissueModelPath IS NOT NULL
+    ORDER BY m.trainedAt DESC
+    """)
+    Optional<Model> findFirstMultiModelByUser(@Param("modelType") ModelType modelType, @Param("user") User user);
+
 }

--- a/backend/src/main/java/site/pathos/domain/notification/service/UserNotificationService.java
+++ b/backend/src/main/java/site/pathos/domain/notification/service/UserNotificationService.java
@@ -18,10 +18,11 @@ import site.pathos.domain.notification.repository.NotificationTypeRepository;
 import site.pathos.domain.notification.repository.UserNotificationRepository;
 import site.pathos.domain.notification.repository.UserNotificationSettingRepository;
 import site.pathos.domain.user.entity.User;
-import site.pathos.domain.user.repository.UserRepository;
+import site.pathos.domain.user.service.UserService;
 import site.pathos.global.common.PaginationResponse;
 import site.pathos.global.error.BusinessException;
 import site.pathos.global.error.ErrorCode;
+import site.pathos.global.security.util.SecurityUtil;
 import site.pathos.global.util.datetime.DateTimeUtils;
 
 @Service
@@ -31,7 +32,7 @@ public class UserNotificationService {
     private final NotificationTypeRepository notificationTypeRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
     private final UserNotificationRepository userNotificationRepository;
-    private final UserRepository userRepository;
+    private final UserService userService;
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     @Transactional
@@ -75,9 +76,7 @@ public class UserNotificationService {
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
         Pageable pageable = PageRequest.of(pageIndex, DEFAULT_PAGE_SIZE, sort);
-
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User user = userService.getCurrentUser();
 
         Page<UserNotification> pageData = userNotificationRepository.findByUser(user, pageable);
 
@@ -103,7 +102,7 @@ public class UserNotificationService {
 
     @Transactional
     public void readNotification(Long notificationId) {
-        Long userId = 1L;
+        Long userId = SecurityUtil.getCurrentUserId();
         UserNotification notification = userNotificationRepository.findById(notificationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
 

--- a/backend/src/main/java/site/pathos/domain/notification/service/UserNotificationSettingService.java
+++ b/backend/src/main/java/site/pathos/domain/notification/service/UserNotificationSettingService.java
@@ -15,6 +15,7 @@ import site.pathos.domain.user.dto.UpdateNotificationSettingsRequestDto;
 import site.pathos.domain.user.entity.User;
 import site.pathos.global.error.BusinessException;
 import site.pathos.global.error.ErrorCode;
+import site.pathos.global.security.util.SecurityUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +41,7 @@ public class UserNotificationSettingService {
 
     @Transactional
     public void updateNotificationSettings(UpdateNotificationSettingsRequestDto request) {
-        Long userId = 1L;   //TODO
+        Long userId = SecurityUtil.getCurrentUserId();
         List<UserNotificationSetting> settings = userNotificationSettingRepository.findByUserIdWithType(userId);
         Map<String, UserNotificationSetting> settingMap = settings.stream()
                 .collect(Collectors.toMap(

--- a/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/site/pathos/domain/project/repository/ProjectRepository.java
@@ -2,7 +2,6 @@ package site.pathos.domain.project.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,11 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.user.entity.User;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-    Page<Project> findAll(Pageable pageable);
-    Page<Project> findByTitleContainingIgnoreCase(String title, Pageable pageable);
+    Page<Project> findAllByUser(User user, Pageable pageable);
+    Page<Project> findByTitleContainingIgnoreCaseAndUser(String title, User user, Pageable pageable);
 
     @Query("""
         SELECT DISTINCT p FROM Project p

--- a/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/site/pathos/domain/project/service/ProjectService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,14 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import site.pathos.domain.annotation.entity.AnnotationHistory;
 import site.pathos.domain.annotation.repository.AnnotationHistoryRepository;
-import site.pathos.domain.project.entity.ProjectLabel;
 import site.pathos.domain.annotation.repository.ProjectLabelRepository;
+import site.pathos.domain.model.entity.Model;
+import site.pathos.domain.model.entity.ProjectModel;
+import site.pathos.domain.model.enums.ModelType;
 import site.pathos.domain.model.repository.ModelRepository;
 import site.pathos.domain.model.repository.ProjectModelRepository;
-import site.pathos.domain.model.entity.Model;
-import site.pathos.domain.model.enums.ModelType;
-import site.pathos.domain.model.entity.ProjectModel;
+import site.pathos.domain.model.repository.UserModelRepository;
 import site.pathos.domain.project.dto.request.CreateProjectRequestDto;
+import site.pathos.domain.project.dto.request.SubProjectTilingRequestDto;
 import site.pathos.domain.project.dto.request.UpdateProjectRequestDto;
 import site.pathos.domain.project.dto.response.GetProjectDetailResponseDto;
 import site.pathos.domain.project.dto.response.GetProjectDetailResponseDto.AnalyticsDto;
@@ -32,21 +32,21 @@ import site.pathos.domain.project.dto.response.GetProjectDetailResponseDto.Slide
 import site.pathos.domain.project.dto.response.GetProjectsResponseDto;
 import site.pathos.domain.project.dto.response.GetProjectsResponseDto.GetProjectsResponseModelsDto;
 import site.pathos.domain.project.entity.Project;
+import site.pathos.domain.project.entity.ProjectLabel;
+import site.pathos.domain.project.entity.SubProject;
 import site.pathos.domain.project.enums.ModelProcessStatusType;
 import site.pathos.domain.project.enums.ProjectSortType;
 import site.pathos.domain.project.repository.ProjectRepository;
-import site.pathos.domain.project.dto.request.SubProjectTilingRequestDto;
-import site.pathos.domain.project.entity.SubProject;
 import site.pathos.domain.project.repository.SubProjectRepository;
 import site.pathos.domain.user.entity.User;
-import site.pathos.domain.user.repository.UserRepository;
-import site.pathos.domain.model.repository.UserModelRepository;
+import site.pathos.domain.user.service.UserService;
 import site.pathos.global.aws.ec2.Ec2Service;
 import site.pathos.global.aws.s3.S3Service;
 import site.pathos.global.aws.s3.dto.S3UploadFileDto;
 import site.pathos.global.common.PaginationResponse;
 import site.pathos.global.error.BusinessException;
 import site.pathos.global.error.ErrorCode;
+import site.pathos.global.security.util.SecurityUtil;
 import site.pathos.global.util.datetime.DateTimeUtils;
 
 @Service
@@ -55,30 +55,28 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final SubProjectRepository subProjectRepository;
     private final AnnotationHistoryRepository annotationHistoryRepository;
-    private final UserRepository userRepository;
     private final S3Service s3Service;
     private final ModelRepository modelRepository;
     private final UserModelRepository userModelRepository;
     private final Ec2Service ec2Service;
+    private final UserService userService;
     private static final int PROJECTS_PAGE_SIZE = 9;
     private final ProjectModelRepository projectModelRepository;
     private final ProjectLabelRepository projectLabelRepository;
 
     @Transactional
     public void createProject(CreateProjectRequestDto requestDto, List<MultipartFile> files) {
-        User user = userRepository.findById(1L) //TODO
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
+        User user = userService.getCurrentUser();
         Model model;
         if (requestDto.modelId() == null) {
             if (requestDto.modelType() == ModelType.TISSUE) {
-                model = modelRepository.findFirstByTrainingHistoryIsNullAndModelTypeAndTissueModelPathIsNotNullAndCellModelPathIsNullOrderByTrainedAtDesc(ModelType.TISSUE)
+                model = modelRepository.findFirstTissueModelByUser(ModelType.TISSUE, user)
                         .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_ERROR));
             } else if (requestDto.modelType() == ModelType.CELL) {
-                model = modelRepository.findFirstByTrainingHistoryIsNullAndModelTypeAndCellModelPathIsNotNullAndTissueModelPathIsNullOrderByTrainedAtDesc(ModelType.CELL)
+                model = modelRepository.findFirstCellModelByUser(ModelType.CELL, user)
                         .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_ERROR));
             } else if (requestDto.modelType() == ModelType.MULTI) {
-                model = modelRepository.findFirstByTrainingHistoryIsNullAndModelTypeAndCellModelPathIsNotNullAndTissueModelPathIsNotNullOrderByTrainedAtDesc(ModelType.MULTI)
+                model = modelRepository.findFirstMultiModelByUser(ModelType.MULTI, user)
                         .orElseThrow(() -> new BusinessException(ErrorCode.INTERNAL_ERROR));
             } else {
                 throw new BusinessException(ErrorCode.INTERNAL_ERROR); // 잘못된 modelType 처리
@@ -148,7 +146,8 @@ public class ProjectService {
     }
 
     private List<GetProjectsResponseModelsDto> getModels() {
-        List<Model> models = userModelRepository.findAllModelsByUserId(1L);
+        Long userId = SecurityUtil.getCurrentUserId();
+        List<Model> models = userModelRepository.findAllModelsByUserId(userId);
 
         return models
                 .stream()
@@ -157,13 +156,14 @@ public class ProjectService {
     }
 
     private Page<Project> getProjectPage(String search, ProjectSortType sort, int page) {
+        User user = userService.getCurrentUser();
         Pageable pageable = PageRequest.of(page - 1, PROJECTS_PAGE_SIZE, sort.getSort());
 
         Page<Project> projectPage;
         if (search != null && !search.isBlank()) {
-            projectPage = projectRepository.findByTitleContainingIgnoreCase(search, pageable);
+            projectPage = projectRepository.findByTitleContainingIgnoreCaseAndUser(search, user, pageable);
         } else {
-            projectPage = projectRepository.findAll(pageable);
+            projectPage = projectRepository.findAllByUser(user, pageable);
         }
         return projectPage;
     }
@@ -230,7 +230,7 @@ public class ProjectService {
 
     @Transactional
     public void updateProject(Long projectId, UpdateProjectRequestDto requestDto) {
-        Long userId = 1L;   // TODO
+        Long userId = SecurityUtil.getCurrentUserId();
         Project project = getProject(projectId, userId);
 
         project.updateDetail(requestDto.title(), requestDto.description());
@@ -238,7 +238,7 @@ public class ProjectService {
 
     @Transactional
     public void deleteProject(Long projectId) {
-        Long userId = 1L;   // TODO
+        Long userId = SecurityUtil.getCurrentUserId();
         Project project = getProject(projectId, userId);
 
         project.delete();
@@ -246,7 +246,7 @@ public class ProjectService {
 
     @Transactional(readOnly = true)
     public GetProjectDetailResponseDto getProjectDetail(Long projectId) {
-        Long userId = 1L;   // TODO
+        Long userId = SecurityUtil.getCurrentUserId();
         Project project = getProject(projectId, userId);
 
         List<SubProject> subProjects = getSubProjects(project);

--- a/backend/src/main/java/site/pathos/global/error/ErrorCode.java
+++ b/backend/src/main/java/site/pathos/global/error/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "해당 유저의 알림 설정을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),
     NO_NOTIFICATION_ACCESS(HttpStatus.FORBIDDEN, "해당 알림에 접근 권한이 없습니다."),
-    NO_NOTIFICATION_SETTING(HttpStatus.BAD_REQUEST, "알림 설정 값이 필요합니다.")
+    NO_NOTIFICATION_SETTING(HttpStatus.BAD_REQUEST, "알림 설정 값이 필요합니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 리프레시 토큰입니다."),
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/site/pathos/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/pathos/global/security/jwt/JwtAuthenticationFilter.java
@@ -48,7 +48,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void mockAuthenticateAsUserId1() {
-        User user = userRepository.findById(1L)
+        Long mockUserId = 1L;
+        User user = userRepository.findById(mockUserId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         CustomOAuth2User mockPrincipal = new CustomOAuth2User(user);
 


### PR DESCRIPTION
## 📝작업 내용

- 하드코딩된 유저 id를 제거하고, SecurityUtil.getCurrentUserId()를 통해 현재 로그인한 사용자의 ID를 동적으로 가져오도록 수정
- AuthService, UserService, ProjectService 서비스 계층에서 이 변경을 적용