### PR TITLE
[ BE ] feat/#172 알림 기능 리팩토링

### DIFF
--- a/backend/src/main/java/site/pathos/domain/notification/constants/NotificationsConstants.java
+++ b/backend/src/main/java/site/pathos/domain/notification/constants/NotificationsConstants.java
@@ -1,0 +1,20 @@
+package site.pathos.domain.notification.constants;
+
+public class NotificationsConstants {
+    private NotificationsConstants() {
+    }
+
+    public static final long SSE_EMITTER_DEFAULT_TIMEOUT = 3_600_000L; // 1시간
+    public static final String INIT_EVENT_NAME = "INIT";
+    public static final String INIT_EVENT_DATA = "connected";
+    public static final String NOTIFICATION_EVENT_NAME = "notification";
+    public static final String HEARTBEAT_KEY = "heartbeat:key";
+    public static final String HEARTBEAT_VALUE = "ping";
+    public static final long HEARTBEAT_TTL = 20L;
+    public static final String SSE_HEARTBEAT_COMMENT = "heartbeat";
+    public static final String NOTIFY_KEYSPACE_EVENTS_CONFIG = "notify-keyspace-events";
+    public static final String EXPIRED_EVENTS_CONFIG_VALUE = "Ex";
+    public static final String NOTIFICATION_CHANNEL_PREFIX = "notifications.";
+    public static final String NOTIFICATION_CHANNEL_PATTERN = "notifications.*";
+    public static final String HEARTBEAT_CHANNEL_PATTERN = "__keyevent@0__:expired";
+}

--- a/backend/src/main/java/site/pathos/domain/notification/controller/NotificationController.java
+++ b/backend/src/main/java/site/pathos/domain/notification/controller/NotificationController.java
@@ -3,6 +3,8 @@ package site.pathos.domain.notification.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -10,8 +12,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.pathos.domain.notification.dto.response.GetNotificationsResponseDto;
 import site.pathos.domain.notification.service.UserNotificationService;
+import site.pathos.domain.notification.sse.EmitterRegistry;
 import site.pathos.global.common.PaginationResponse;
 
 @Tag(name = "Notification API", description = "알림 기능 API")
@@ -21,6 +25,7 @@ import site.pathos.global.common.PaginationResponse;
 public class NotificationController {
 
     private final UserNotificationService userNotificationService;
+    private final EmitterRegistry registry;
 
     @Operation(summary = "알림 목록을 조회합니다.")
     @GetMapping
@@ -39,5 +44,16 @@ public class NotificationController {
     ) {
         userNotificationService.readNotification(notificationId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "SSE 방식을 위한 알림 구독")
+    @GetMapping("/subscribe")
+    public ResponseEntity<SseEmitter> subscribe() {
+        SseEmitter sseEmitter = registry.create();
+        return ResponseEntity
+                .ok()
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .contentType(MediaType.TEXT_EVENT_STREAM)
+                .body(sseEmitter);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/notification/sse/EmitterRegistry.java
+++ b/backend/src/main/java/site/pathos/domain/notification/sse/EmitterRegistry.java
@@ -1,0 +1,73 @@
+package site.pathos.domain.notification.sse;
+
+import static site.pathos.domain.notification.constants.NotificationsConstants.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import site.pathos.global.security.util.SecurityUtil;
+
+@Component
+public class EmitterRegistry {
+    private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter create() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        SseEmitter emitter = new SseEmitter(SSE_EMITTER_DEFAULT_TIMEOUT);
+        emitters.computeIfAbsent(userId, id -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        emitter.onCompletion(() -> remove(userId, emitter));
+        emitter.onTimeout(() -> remove(userId, emitter));
+        emitter.onError((e) -> remove(userId, emitter));
+
+        try {
+            emitter.send(
+                    SseEmitter.event().name(INIT_EVENT_NAME).data(INIT_EVENT_DATA)
+            );
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    public void remove(Long userId, SseEmitter emitter) {
+        List<SseEmitter> list = emitters.get(userId);
+        if (list != null) {
+            list.remove(emitter);
+            if (list.isEmpty()) emitters.remove(userId);
+        }
+    }
+
+    public void sendToUser(Long userId, String data) {
+        List<SseEmitter> sseEmitters = emitters.get(userId);
+        if (sseEmitters == null) {
+            return;
+        }
+        for (SseEmitter emitter : sseEmitters) {
+            try {
+                emitter.send(
+                        SseEmitter.event().name(NOTIFICATION_EVENT_NAME).data(data)
+                );
+            } catch (Exception ex) {
+                emitter.completeWithError(ex);
+                remove(userId, emitter);
+            }
+        }
+    }
+
+    public Map<Long, List<SseEmitter>> getAllSnapshot() {
+        Map<Long, List<SseEmitter>> snapshot = new HashMap<>();
+        emitters.forEach((userId, list) ->
+                snapshot.put(userId, Collections.unmodifiableList(new ArrayList<>(list)))
+        );
+        return Collections.unmodifiableMap(snapshot);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/notification/sse/HeartbeatKeyExpirationListener.java
+++ b/backend/src/main/java/site/pathos/domain/notification/sse/HeartbeatKeyExpirationListener.java
@@ -1,0 +1,56 @@
+package site.pathos.domain.notification.sse;
+
+import static site.pathos.domain.notification.constants.NotificationsConstants.*;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class HeartbeatKeyExpirationListener implements MessageListener {
+    private final EmitterRegistry registry;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @PostConstruct
+    public void initialize() {
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            connection.serverCommands().setConfig(NOTIFY_KEYSPACE_EVENTS_CONFIG, EXPIRED_EVENTS_CONFIG_VALUE);
+            return null;
+        });
+
+        // 최초 heartbeat 설정
+        redisTemplate.opsForValue().set(HEARTBEAT_KEY, HEARTBEAT_VALUE, HEARTBEAT_TTL, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = new String(message.getBody(), StandardCharsets.UTF_8);
+        if (!HEARTBEAT_KEY.equals(expiredKey)) {
+            return;
+        }
+
+        registry.getAllSnapshot().forEach((userId, list) -> {
+            list.forEach(emitter -> {
+                try {
+                    emitter.send(
+                            SseEmitter.event().comment(SSE_HEARTBEAT_COMMENT)
+                    );
+                } catch (IOException e) {
+                    emitter.completeWithError(e);
+                    registry.remove(userId, emitter);
+                }
+            });
+        });
+
+        redisTemplate.opsForValue().set(HEARTBEAT_KEY, HEARTBEAT_VALUE, HEARTBEAT_TTL, TimeUnit.SECONDS);
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/notification/sse/RedisNotificationListener.java
+++ b/backend/src/main/java/site/pathos/domain/notification/sse/RedisNotificationListener.java
@@ -1,0 +1,20 @@
+package site.pathos.domain.notification.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisNotificationListener implements MessageListener {
+    private final EmitterRegistry registry;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String channel = new String(message.getChannel(), java.nio.charset.StandardCharsets.UTF_8);
+        Long userId = Long.valueOf(channel.split("\\.")[1]);
+        String payload = new String(message.getBody(), java.nio.charset.StandardCharsets.UTF_8);
+        registry.sendToUser(userId, payload);
+    }
+}

--- a/backend/src/main/java/site/pathos/global/config/RedisConfig.java
+++ b/backend/src/main/java/site/pathos/global/config/RedisConfig.java
@@ -1,11 +1,19 @@
 package site.pathos.global.config;
 
+import static site.pathos.domain.notification.constants.NotificationsConstants.*;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import site.pathos.domain.notification.sse.HeartbeatKeyExpirationListener;
+import site.pathos.domain.notification.sse.RedisNotificationListener;
 
 @Configuration
 public class RedisConfig {
@@ -25,6 +33,31 @@ public class RedisConfig {
     public RedisTemplate<String, String> redisTemplate(LettuceConnectionFactory cf) {
         RedisTemplate<String,String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(cf);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            MessageListenerAdapter notificationListenerAdapter,
+            MessageListenerAdapter heartbeatListenerAdapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(notificationListenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL_PATTERN));
+        container.addMessageListener(heartbeatListenerAdapter, new PatternTopic(HEARTBEAT_CHANNEL_PATTERN));
+        return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter notificationListenerAdapter(RedisNotificationListener subscriber) {
+        return new MessageListenerAdapter(subscriber, "onMessage");
+    }
+
+    @Bean
+    public MessageListenerAdapter heartbeatListenerAdapter(HeartbeatKeyExpirationListener listener) {
+        return new MessageListenerAdapter(listener, "onMessage");
     }
 }

--- a/backend/src/main/java/site/pathos/global/error/ErrorCode.java
+++ b/backend/src/main/java/site/pathos/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     SHARED_PROJECT_COMMENT_MISMATCH(HttpStatus.BAD_REQUEST, "요청한 프로젝트와 댓글의 프로젝트가 일치하지 않습니다."),
     NO_COMMENT_UPDATE_PERMISSION(HttpStatus.FORBIDDEN, "해당 댓글의 수정 권한이 없습니다"),
     NO_COMMENT_DELETE_PERMISSION(HttpStatus.FORBIDDEN, "해당 댓글의 삭제 권한이 없습니다"),
+    REDIS_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 알림 발송에 실패했습니다."),
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #172

## 📝작업 내용

- 퍼블릭 스페이스 댓글 작성시 알림 발송되도록 구현했습니다.
- 추후 다중 서버 환경에서도 Redis Pub/Sub를 통해 확장 가능하도록 고려되어 있습니다.
- 기존 알림 전송 방식(Polling 또는 단순 요청 기반 전송)을 SSE(Server-Sent Events) 기반으로 개선했습니다.
- heartbeat 주기를 통해 연결 상태를 유지하며, 만료 시 자동으로 재설정되는 구조를 적용했습니다.
- Redis의 Key Expiration 이벤트를 활용하여 클라이언트에게 주기적인 ping 메시지를 전송합니다.