### PR TITLE
[ BE ] feat/#177 프로젝트 학습 성능 지표 저장 및 조회 구현

### DIFF
--- a/backend/src/main/java/site/pathos/domain/model/entity/InferenceHistory.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/InferenceHistory.java
@@ -29,13 +29,13 @@ public class InferenceHistory {
     private Model baseModel;
 
     @Column(name = "accuracy")
-    private Float accuracy;
+    private Double accuracy;
 
     @Column(name = "loss")
-    private Float loss;
+    private Double loss;
 
     @Column(name = "loop_performance")
-    private Float loopPerformance;
+    private Double loopPerformance;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -50,8 +50,7 @@ public class InferenceHistory {
         this.baseModel = model;
     }
 
-
-    public void updateResult(float accuracy, float loss, float loopPerformance) {
+    public void updateResult(double accuracy, double loss, double loopPerformance) {
         this.accuracy = accuracy;
         this.loss = loss;
         this.loopPerformance = loopPerformance;

--- a/backend/src/main/java/site/pathos/domain/model/entity/ProjectMetric.java
+++ b/backend/src/main/java/site/pathos/domain/model/entity/ProjectMetric.java
@@ -1,0 +1,47 @@
+package site.pathos.domain.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.pathos.domain.model.enums.MetricType;
+import site.pathos.domain.project.entity.Project;
+
+@Entity
+@Table(name = "project_metric")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectMetric {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_type", nullable = false)
+    private MetricType metricType;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Builder
+    public ProjectMetric(Project project, MetricType metricType, Double score) {
+        this.project = project;
+        this.metricType = metricType;
+        this.score = score;
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/model/enums/MetricType.java
+++ b/backend/src/main/java/site/pathos/domain/model/enums/MetricType.java
@@ -1,0 +1,75 @@
+package site.pathos.domain.model.enums;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+
+public enum MetricType {
+    ACCURACY {
+        @Override
+        public boolean matches(String line) {
+            line = line.toLowerCase(Locale.ROOT);
+            return line.startsWith("mean acc:");
+        }
+
+        @Override
+        public double parseValue(String line) {
+            return parseAfterColon(line);
+        }
+    },
+    IOU {
+        @Override
+        public boolean matches(String line) {
+            line = line.toLowerCase(Locale.ROOT);
+            return line.startsWith("mean iou:");
+        }
+
+        @Override
+        public double parseValue(String line) {
+            return parseAfterColon(line);
+        }
+    },
+    LOSS {
+        @Override
+        public boolean matches(String line) {
+            line = line.toLowerCase(Locale.ROOT);
+            return line.startsWith("epoch") && line.contains("loss=");
+        }
+
+        @Override
+        public double parseValue(String line) {
+            int index = line.toLowerCase(Locale.ROOT).indexOf("loss=");
+            String valuePart = line.substring(index + 5).trim().split("\\s")[0];
+            return Double.parseDouble(valuePart);
+        }
+    },
+    FAULTY {
+        @Override
+        public boolean matches(String line) {
+            return true;
+        }
+
+        @Override
+        public double parseValue(String line) {
+            return 0L;
+        }
+    }
+    ;
+
+    public abstract boolean matches(String line);
+    public abstract double parseValue(String line);
+
+    public static Optional<MetricType> parseLine(String line) {
+        return Arrays.stream(values())
+                .filter(type -> type.matches(line))
+                .findFirst();
+    }
+
+    private static double parseAfterColon(String line) {
+        try {
+            return Double.parseDouble(line.split(":")[1].trim());
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+}

--- a/backend/src/main/java/site/pathos/domain/model/repository/ProjectMetricRepository.java
+++ b/backend/src/main/java/site/pathos/domain/model/repository/ProjectMetricRepository.java
@@ -1,0 +1,12 @@
+package site.pathos.domain.model.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.pathos.domain.model.entity.ProjectMetric;
+import site.pathos.domain.project.entity.Project;
+
+@Repository
+public interface ProjectMetricRepository extends JpaRepository<ProjectMetric, Long> {
+    List<ProjectMetric> findAllByProject(Project project);
+}

--- a/backend/src/main/java/site/pathos/domain/model/service/ModelServerService.java
+++ b/backend/src/main/java/site/pathos/domain/model/service/ModelServerService.java
@@ -1,9 +1,16 @@
 package site.pathos.domain.model.service;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,31 +31,38 @@ import site.pathos.domain.model.dto.TrainingResultRequestDto;
 import site.pathos.domain.model.entity.InferenceHistory;
 import site.pathos.domain.model.entity.Model;
 import site.pathos.domain.model.entity.ModelLabel;
+import site.pathos.domain.model.entity.ProjectMetric;
 import site.pathos.domain.model.entity.ProjectModel;
 import site.pathos.domain.model.entity.TrainingHistory;
+import site.pathos.domain.model.enums.MetricType;
 import site.pathos.domain.model.enums.ModelRequestType;
 import site.pathos.domain.model.event.ProjectRunCompletedEvent;
 import site.pathos.domain.model.event.ProjectTrainCompletedEvent;
 import site.pathos.domain.model.repository.InferenceHistoryRepository;
+import site.pathos.domain.model.repository.ProjectMetricRepository;
 import site.pathos.domain.model.repository.ProjectModelRepository;
 import site.pathos.domain.model.repository.TrainingHistoryRepository;
 import site.pathos.domain.project.entity.Project;
 import site.pathos.domain.project.entity.SubProject;
 import site.pathos.domain.project.repository.ProjectRepository;
 import site.pathos.domain.project.repository.SubProjectRepository;
+import site.pathos.global.aws.s3.S3Service;
 import site.pathos.global.aws.sqs.service.SqsService;
 import site.pathos.global.error.BusinessException;
 import site.pathos.global.error.ErrorCode;
 import site.pathos.global.util.color.ColorUtils;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ModelServerService {
     private final AnnotationHistoryRepository annotationHistoryRepository;
     private final TissueAnnotationRepository tissueAnnotationRepository;
     private final CellAnnotationRepository cellAnnotationRepository;
     private final TrainingHistoryRepository trainingHistoryRepository;
     private final InferenceHistoryRepository inferenceHistoryRepository;
+    private final ProjectMetricRepository projectMetricRepository;
 
     private final ModelService modelService;
     private final SqsService sqsService;
@@ -60,11 +74,13 @@ public class ModelServerService {
     private final RoiRepository roiRepository;
     private final TrainingHistoryService trainingHistoryService;
     private final TissueAnnotationService tissueAnnotationService;
+    private final S3Service s3Service;
 
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void requestTraining(Long projectId, TrainingRequestDto trainingRequestDto) {
+
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
@@ -199,9 +215,6 @@ public class ModelServerService {
         InferenceHistory inferenceHistory = inferenceHistoryRepository.findById(resultRequestDto.inferenceHistoryId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.INFERENCE_HISTORY_NOT_FOUND));
 
-        TrainingResultRequestDto.Performance performance = resultRequestDto.performance();
-        inferenceHistory.updateResult(performance.accuracy(), performance.loss(), performance.loopPerformance());
-
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
@@ -258,6 +271,7 @@ public class ModelServerService {
                 tissueAnnotationService.saveResultAnnotation(roi, roiDto.tissuePath());
             }
         }
+        createMetric(project, inferenceHistory);
         publishCompletedEvent(resultRequestDto.type(), project);
     }
 
@@ -279,5 +293,56 @@ public class ModelServerService {
                     )
             );
         }
+    }
+
+    public void createMetric(Project project, InferenceHistory inferenceHistory) {
+        String key = "log.txt";
+        try {
+            InputStream inputStream = s3Service.downloadFile(key);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            try (inputStream; reader) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    final String currentLine = line;
+
+                    Optional<MetricType> optionalType = MetricType.parseLine(currentLine);
+                    if (optionalType.isEmpty()) {
+                        continue;
+                    }
+
+                    MetricType type = optionalType.get();
+                    double value = type.parseValue(currentLine);
+                    ProjectMetric projectMetric = ProjectMetric.builder()
+                            .project(project)
+                            .metricType(type)
+                            .score(value)
+                            .build();
+                    projectMetricRepository.save(projectMetric);
+                }
+            }
+            updateProjectMetric(project, inferenceHistory);
+        } catch (FileNotFoundException | S3Exception e) {
+            log.warn("S3에 log.txt 파일이 존재하지 않아 Metric 생성을 건너뜁니다. key={}", key);
+        } catch (IOException e) {
+            log.error("프로젝트 Metric 업데이트에 실패했습니다. I/O 에러", e);
+        }
+    }
+
+    private void updateProjectMetric(Project project, InferenceHistory inferenceHistory) {
+        List<ProjectMetric> projectMetrics = projectMetricRepository.findAllByProject(project);
+
+        double accuracyAverage = calculateAverage(projectMetrics, MetricType.ACCURACY);
+        double lossAverage = calculateAverage(projectMetrics, MetricType.LOSS);
+        double iouAverage = calculateAverage(projectMetrics, MetricType.IOU);
+
+        inferenceHistory.updateResult(accuracyAverage, lossAverage, iouAverage);
+    }
+
+    private double calculateAverage(List<ProjectMetric> projectMetrics, MetricType type) {
+        return projectMetrics.stream()
+                .filter(projectMetric -> projectMetric.getMetricType() == type)
+                .mapToDouble(ProjectMetric::getScore)
+                .average()
+                .orElse(0.0);
     }
 }

--- a/backend/src/main/java/site/pathos/domain/project/dto/response/GetProjectDetailResponseDto.java
+++ b/backend/src/main/java/site/pathos/domain/project/dto/response/GetProjectDetailResponseDto.java
@@ -72,8 +72,6 @@ public record GetProjectDetailResponseDto(
     }
 
     public record AnalyticsDto(
-            @Schema(description = "epoch 목록", example = "[1, 2, 3, 4, 5]")
-            List<Integer> epochs,
             @Schema(description = "epoch별 loss 값", example = "[0.9, 0.75, 0.5, 0.3, 0.25]")
             List<Double> loss,
             @Schema(description = "epoch별 IoU 값", example = "[0.4, 0.6, 0.65, 0.73, 0.75]")


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #177 

## 📝작업 내용

- 프로젝트 학습 및 추론 후에 생성되는 성능 지표를 가져와서 저장한다.
- 프로젝트 상세 조회시에 성능 지표를 포함한다.
